### PR TITLE
add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+*.swp
+*.pyc


### PR DESCRIPTION
Adds a `.gitignore` file to force ignore random system and editor files. This branch also potentially fixes an issue I encountered after switching to master from the gh-pages branch. `bower_components/` and `docs/` were left around in the working directory - so I used `git rm` to remove them in order for git to register my file system changes.

@chfogerty @cmbrose @theMagicalKarp @zach-taylor 
If I could get your +1 on this, we merge this in real quick. After the merge, if you have any outstanding branches, be sure to stash your uncommitted changes, checkout master, `git fetch origin`, `git pull origin master`, checkout your work branch, and `git merge master` into that branch. Thanks!
