### PR TITLE
The Great Front-end Migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 *.pyc
 *.exe
 *.pem
+
+# front-end
+node_modules
+bower_components

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,8 @@ WORKDIR /data/lighthouse
 
 RUN go get github.com/fsouza/go-dockerclient
 
-RUN npm install -g gulp
+RUN npm install
+RUN npm install gulp
+RUN gulp build
 
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH
 
 WORKDIR /data
 
-
 # ----- Add private ssh key -----
 RUN mkdir -p /root/.ssh
 
@@ -56,13 +55,20 @@ RUN echo "Host github.com\n\tStrictHostKeyChecking no\n" >> /root/.ssh/config
 # ----- Setup enviroment -----
 RUN git clone git@github.com:ngmiller/lighthouse.git
 WORKDIR /data/lighthouse
-# You can play around with which branch you want the build use. Master is default.
-# RUN git checkout -b some-branch origin/some-branch
+
+RUN git fetch origin
+# Set your development branch here; uncomment for a production deploy
+# RUN git checkout <DEV BRANCH NAME HERE>
 
 RUN go get github.com/fsouza/go-dockerclient
 
+# Build front-end
+WORKDIR /data/lighthouse/client
 RUN npm install
-RUN npm install gulp
+RUN npm install -g gulp
 RUN gulp build
+
+# Build/run server
+WORKDIR /data/lighthouse/backend/static
 
 EXPOSE 5000

--- a/client/Gulpfile.js
+++ b/client/Gulpfile.js
@@ -1,0 +1,71 @@
+//
+// Build
+//
+var browserify = require('browserify'),
+    buffer = require('vinyl-buffer'),
+    gulp  = require('gulp'),
+    jshint = require('gulp-jshint'),
+    rimraf = require('rimraf'),
+    source = require('vinyl-source-stream'),
+    uglify = require('gulp-uglify');
+
+// Build artifact final location
+var staticRoot = '../backend/static/';
+
+// Build app and assets
+gulp.task('build', ['jshint', 'browserify', 'views']);
+
+// JSHint
+gulp.task('jshint', function () {
+    gulp.src('./app/js/**/*.js')
+    .pipe(jshint())
+    .pipe(jshint.reporter('default'));
+});
+
+// Browserify task for js assets
+// -- This will package our app into a single file for distribution
+gulp.task('browserify', function() {
+    // do magic
+    browserify('./app/js/main.js', {
+        debug: true
+        // insertGlobals: true,
+    })
+    .bundle()
+    // Bundle to a single file
+    .pipe(source('app.js'))
+    // convert to buffer for use by uglify (doesn't like streams)
+    .pipe(buffer())
+    // minify
+    .pipe(uglify())
+    // Output it to our dist folder
+    .pipe(gulp.dest(staticRoot + 'js/'));
+});
+
+// View task for html assets
+gulp.task('views', function () {
+    gulp.src('./app/*.html')
+    .pipe(gulp.dest(staticRoot))
+});
+
+// Watch for source updates
+gulp.task('watch', ['jshint'], function() {
+    gulp.watch(['./app/js/*.js', './app/js/**/*.js',
+                './app/*.html', './app/**/*.html'],[
+        'build'
+    ]);
+});
+
+// Clean build artifacts
+gulp.task('clean', function () {
+    rimraf(staticRoot + 'index.html', function (er) {
+        if (er) {
+            console.log(er);
+        }
+    });
+
+    rimraf(staticRoot + 'js', function (er) {
+        if (er) {
+            console.log(er);
+        }
+    });
+});

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en" ng-app="dockerThing">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <title>Docker Thang</title>
+
+    <link rel="stylesheet" href="/static/css/picnic.css">
+    <link rel="stylesheet" href="/static/css/base.css">
+</head>
+
+<body>
+
+<nav>
+  <a href="#" class="main" style="">Docker Thing</a>
+</nav>
+
+<div class="container" ng-controller="mainController">
+    <h6>Attention all planets of the solar federation... we have assumed control.</h6>
+
+    <h1>Containers</h1>
+    <div id="containers" class="row">
+        <table class="primary">
+            <thead>
+                <tr>
+                    <th>Image</th>
+                    <th>Status</th>
+                    <th>Created</th>
+                    <th>Ports</th>
+                    <th>Command</th>
+                    <th>Names</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="container in remote.containers">
+                    <td>{{ container.Image }}</td>
+                    <td>{{ container.Status }}</td>
+                    <td>{{ formatTime(container.Created) }}</td>
+                    <td>{{ container.Ports[0].IP }} : {{ container.Ports[0].PublicPort }} -> {{ container.Ports[0].PrivatePort }} / {{ container.Ports[0].Type }}</td>
+                    <td>{{ container.Command }}</td>
+                    <td>{{ container.Names }}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <h1>Images</h1>
+    <div id="images" class="row">
+        <table class="primary">
+            <thead>
+                <th>RepoTags</th>
+                <th>ID</th>
+                <th>Created</th>
+            </thead>
+            <tbody>
+                <tr ng-repeat="image in remote.images">
+                    <td>{{ image.RepoTags }}</td>
+                    <td>{{ image.Id }}</td>
+                    <td>{{ formatTime(image.Created) }}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <h1>Info</h1>
+    <div id="info" class="row"><pre>{{ remote.info }}</pre></div>
+</div>
+
+<script src="/static/js/app.js"></script>
+
+</body>
+</html>

--- a/client/app/js/controllers/mainController.js
+++ b/client/app/js/controllers/mainController.js
@@ -1,0 +1,68 @@
+/*
+ * mainController
+ * Initial view control
+ */
+function mainController($scope, dockerService) {
+    'use strict';
+
+    // Host information wrapper
+    $scope.remote = {};
+
+    // TODO move to some utility service
+    $scope.formatTime = function(unixEpoch) {
+        var record = new Date();
+        var year = record.getFullYear();
+        var month = record.getMonth();
+        var date = record.getDate();
+        var hour = record.getHours();
+        var min = record.getMinutes();
+        var sec = record.getSeconds();
+
+        return [
+            month, '/', date, '/', year, ' ', hour, ':', min, ':', sec
+        ].join('');
+    };
+
+    // Basic Docker host information
+    dockerService.getInfo().then(
+        // success
+        function (response) {
+            $scope.remote.info = JSON.stringify(response.data, null, " ");
+        },
+        // error
+        function (response) {
+            // TODO generate an alertService to show toast alerts on API failures
+            console.log('Error retreiving host information');
+            console.log('-> status: ' + response.status);
+        }
+    );
+
+    // Containers on Docker host
+    dockerService.getContainers().then(
+        // success
+        function (response) {
+            $scope.remote.containers = response.data;
+        },
+        // error
+        function (response) {
+            console.log('Error retreiving host containers');
+            console.log('-> status: ' + response.status);
+        }
+    );
+
+    // Images on Docker host
+    dockerService.getImages().then(
+        // success
+        function (response) {
+            $scope.remote.images = response.data;
+        },
+        // error
+        function (response) {
+            console.log('Error retreiving host images');
+            console.log('-> status: ' + response.status);
+        }
+    );
+}
+
+mainController.$inject = ['$scope', 'dockerService'];
+module.exports = mainController;

--- a/client/app/js/main.js
+++ b/client/app/js/main.js
@@ -1,0 +1,13 @@
+
+var angular = require('angular'),
+    mainController = require('./controllers/mainController'),
+    dockerService = require('./services/dockerService');
+
+// initialize angular app
+var app = angular.module('dockerThing', []);
+
+// initialize controllers
+app.controller('mainController', mainController);
+
+// initialize factories
+app.factory('dockerService', dockerService);

--- a/client/app/js/services/dockerService.js
+++ b/client/app/js/services/dockerService.js
@@ -1,0 +1,40 @@
+/*
+ * dockerService
+ * Requests docker host and container information
+ */
+function dockerService($http) {
+    /*
+     * getInfo
+     * GET /info
+     */
+    function getInfo() {
+        return $http.get('/info',  {
+            'responseType': 'text'
+        });
+    }
+
+    /*
+     * getContainers
+     * GET /containers
+     */
+    function getContainers() {
+        return $http.get('/containers');
+    }
+
+    /*
+     * getImages
+     * GET /images
+     */
+    function getImages() {
+        return $http.get('/images');
+    }
+
+    return {
+        'getInfo': getInfo,
+        'getContainers': getContainers,
+        'getImages': getImages
+    };
+}
+
+dockerService.$inject = ['$http'];
+module.exports = dockerService;

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "devDependencies": {
+    "angular": "^1.2.23",
+    "browserify": "^5.12.1",
+    "express": "^4.9.5",
+    "gulp": "^3.8.8",
+    "gulp-jshint": "^1.8.4",
+    "gulp-uglify": "^1.0.1",
+    "rimraf": "^2.2.8",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.0.0"
+  }
+}


### PR DESCRIPTION
https://trello.com/c/llYodwbl/29-move-front-end-from-docker-thing-to-docker-manager

The development bootstrapping process is (maybe) complete. How to run these changes:
1. fire up a boot2docker VM and set up the shared directory as specified in Rob's previous PR
2. open up Dockerfile and uncomment the branch switch to be: `RUN git checkout front-end`
3. `docker build -t test/some-tag .`
4. `docker run -t -i -p 5000:5000 test/some-tag python -m SimpleHTTPServer 5000`

Once the backend server is setup to serve the initial request for `index.html`, we can remove the WORKDIR modifications and that python command for the container run.

Let me know if anything seems odd. Thanks!
