### PR TITLE
GCE Discovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH
 
 WORKDIR /data
 
+RUN apt-get update
+RUN apt-get install -y mercurial
 
 # ----- Add private ssh key -----
 RUN mkdir -p /root/.ssh
@@ -60,6 +62,9 @@ WORKDIR /data/lighthouse
 # RUN git checkout -b some-branch origin/some-branch
 
 RUN go get github.com/fsouza/go-dockerclient
+RUN go get github.com/gorilla/mux
+RUN go get code.google.com/p/goauth2/oauth
+RUN go get code.google.com/p/google-api-go-client/compute/v1
 
 RUN npm install -g gulp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,9 @@ WORKDIR /data/lighthouse
 
 RUN go get github.com/fsouza/go-dockerclient
 RUN go get github.com/gorilla/mux
+RUN go get github.com/gorilla/sessions
+RUN go get github.com/gorilla/securecookie
+RUN go get github.com/bmizerany/pq
 RUN go get code.google.com/p/goauth2/oauth
 RUN go get code.google.com/p/google-api-go-client/compute/v1
 

--- a/backend/app.go
+++ b/backend/app.go
@@ -1,19 +1,44 @@
 package main
 
 import (
-    "./plugins"
-
+    "fmt"
     "net/http"
+    "time"
+
+    "./auth"
+    "./plugins"
 
     "github.com/gorilla/mux"
 )
 
 
+func LoggingMiddleware(h http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        start := time.Now()
+
+        h.ServeHTTP(w, r)
+
+        end := time.Now()
+        latency := end.Sub(start)
+        fmt.Printf("%s %12s %s %s\n",
+            end.Format("2006/01/02 - 15:04:05"), latency, r.Method, r.URL)
+    })
+}
+
+
 func main() {
+    fmt.Println("Starting...")
     r := mux.NewRouter()
+
+    auth.Handle(r)
 
     plugins.Handle(r.PathPrefix("/plugins").Subrouter())
 
-    http.Handle("/", r)
+    ignoreURLs := []string{"/", "/login", "/logout", "/plugins/gce/vms/find"}
+    app := auth.AuthMiddleware(r, ignoreURLs)
+
+    http.Handle("/", LoggingMiddleware(app))
+
+    fmt.Println("Ready...")
     http.ListenAndServe(":5000", nil)
 }

--- a/backend/app.go
+++ b/backend/app.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+    "./plugins"
+
+    "net/http"
+
+    "github.com/gorilla/mux"
+)
+
+
+func main() {
+    r := mux.NewRouter()
+
+    plugins.Handle(r.PathPrefix("/plugins").Subrouter())
+
+    http.Handle("/", r)
+    http.ListenAndServe(":5000", nil)
+}

--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -94,17 +94,15 @@ func (this *Users) CreateUser(email, password string) *Users {
     salt := GenerateSalt()
     saltedPassword := SaltPassword(password, salt)
 
-    insertUsers := fmt.Sprintf("INSERT INTO users VALUES ('%s', '%s', '%s')",
+    this.db.Exec("INSERT INTO users (email, salt, password) VALUES (($1), ($2), ($3))",
         email, salt, saltedPassword)
 
-    this.db.Exec(insertUsers)
     return this
 }
 
 func (this *Users) GetUser(email string) *User {
-    userQuery := fmt.Sprintf(
-        "SELECT email, salt, password FROM users WHERE email = '%s'", email)
-    row := this.db.QueryRow(userQuery)
+    row := this.db.QueryRow(
+        "SELECT email, salt, password FROM users WHERE email = ($1)", email)
 
     user := &User{}
     err := row.Scan(&user.Email, &user.Salt, &user.Password)

--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -1,0 +1,189 @@
+package auth
+
+import (
+    "os"
+    "fmt"
+    "strings"
+    "io/ioutil"
+    "net/http"
+    "database/sql"
+
+    "crypto/sha512"
+    "crypto/rand"
+
+    "encoding/hex"
+    "encoding/json"
+
+    "github.com/gorilla/mux"
+    "github.com/gorilla/sessions"
+    "github.com/gorilla/securecookie"
+
+    _ "github.com/bmizerany/pq"
+)
+
+
+var SECRET_HASH_KEY string
+var CookieStore = sessions.NewCookieStore(securecookie.GenerateRandomKey(32))
+
+func SaltPassword(password, salt string) string {
+    key := fmt.Sprintf("%s:%s:%s", password, salt, SECRET_HASH_KEY)
+
+    sha := sha512.New()
+    sha.Write([]byte(key))
+
+    return hex.EncodeToString(sha.Sum(nil))
+}
+
+func GenerateSalt() string {
+    salt := make([]byte, 16)
+    rand.Read(salt)
+    return hex.EncodeToString(salt)
+}
+
+type User struct {
+    Email string
+    Salt string
+    Password string
+}
+
+type LoginForm struct {
+    Email string
+    Password string
+}
+
+type AuthConfig struct {
+    Admins []User
+    SecretKey string
+}
+
+type Users struct {
+    db *sql.DB
+}
+
+func Connect() *Users {
+    host := os.Getenv("POSTGRES_PORT_5432_TCP_ADDR")
+    var postgresOptions string
+
+    if host == "" { // if running locally
+        postgresOptions = "sslmode=disable"
+    } else { // if running in docker
+        postgresOptions = fmt.Sprintf(
+            "host=%s sslmode=disable user=postgres", host)
+    }
+
+    postgres, err := sql.Open("postgres", postgresOptions)
+
+    if err != nil {
+        fmt.Println(err.Error())
+    }
+
+    return &Users{postgres}
+}
+
+func (this *Users) Init() *Users {
+    this.db.Exec("CREATE TABLE users (email varchar(40), salt char(32), password char(128))")
+    return this
+}
+
+func (this *Users) Drop() *Users {
+    this.db.Exec("DROP TABLE users")
+    return this
+}
+
+func (this *Users) CreateUser(email, password string) *Users {
+    salt := GenerateSalt()
+    saltedPassword := SaltPassword(password, salt)
+
+    insertUsers := fmt.Sprintf("INSERT INTO users VALUES ('%s', '%s', '%s')",
+        email, salt, saltedPassword)
+
+    this.db.Exec(insertUsers)
+    return this
+}
+
+func (this *Users) GetUser(email string) *User {
+    userQuery := fmt.Sprintf(
+        "SELECT email, salt, password FROM users WHERE email = '%s'", email)
+    row := this.db.QueryRow(userQuery)
+
+    user := &User{}
+    err := row.Scan(&user.Email, &user.Salt, &user.Password)
+
+    if err != nil {
+        fmt.Println(err.Error())
+    }
+
+    return user
+}
+
+func LoadAuthConfig() *AuthConfig{
+    var fileName string
+    if _, err := os.Stat("/config/auth.json"); os.IsNotExist(err) {
+        fileName = "../config/auth.json"
+    } else {
+        fileName = "/config/auth.json"
+    }
+    configFile, _ := ioutil.ReadFile(fileName)
+
+    var config AuthConfig
+    json.Unmarshal(configFile, &config)
+    return &config
+}
+
+func AuthMiddleware(h http.Handler, ignorePaths []string) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        if strings.HasPrefix(r.URL.Path, "/static") {
+            h.ServeHTTP(w, r)
+            return
+        }
+
+        for _, path := range ignorePaths {
+            if path == r.URL.Path {
+                h.ServeHTTP(w, r)
+                return
+            }
+        }
+
+        session, _ := CookieStore.Get(r, "auth")
+        if loggedIn, ok := session.Values["logged_in"].(bool); loggedIn && ok {
+            h.ServeHTTP(w, r)
+        } else {
+            w.WriteHeader(http.StatusUnauthorized)
+            fmt.Fprintf(w, "unauthorized")
+        }
+    })
+}
+
+func Handle(r *mux.Router) {
+    users := Connect().Drop().Init()
+    config := LoadAuthConfig()
+
+    SECRET_HASH_KEY = config.SecretKey
+
+    for _, admin := range config.Admins {
+        users.CreateUser(admin.Email, admin.Password)
+    }
+
+    r.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+        session, _ := CookieStore.Get(r, "auth")
+
+        loginForm := &LoginForm{}
+        body, _ := ioutil.ReadAll(r.Body)
+        json.Unmarshal(body, &loginForm)
+
+        user := users.GetUser(loginForm.Email)
+        password := SaltPassword(loginForm.Password, user.Salt)
+        session.Values["logged_in"] = password == user.Password
+
+        session.Save(r, w)
+
+        fmt.Fprintf(w, "%t", session.Values["logged_in"].(bool))
+    }).Methods("POST")
+
+
+    r.HandleFunc("/logout", func(w http.ResponseWriter, r *http.Request) {
+        session, _ := CookieStore.Get(r, "auth")
+        session.Values["logged_in"] = false
+        session.Save(r, w)
+    }).Methods("GET")
+}

--- a/backend/plugins/gce/gce.go
+++ b/backend/plugins/gce/gce.go
@@ -1,0 +1,124 @@
+package gce
+
+import (
+    "fmt"
+    "net/http"
+    "io/ioutil"
+    "encoding/json"
+
+    "github.com/gorilla/mux"
+
+    "code.google.com/p/goauth2/oauth"
+    compute "code.google.com/p/google-api-go-client/compute/v1"
+)
+
+
+var config = &oauth.Config {
+    ClientId: "91093806825-0q1cmch4r6vdknf23ui359kqcqmti7rc.apps.googleusercontent.com",
+    ClientSecret: "h0WEhjlsfofdn711b3NalurD",
+    Scope: "https://www.googleapis.com/auth/compute",
+    AuthURL: "https://accounts.google.com/o/oauth2/auth",
+    TokenURL: "https://accounts.google.com/o/oauth2/token",
+    RedirectURL: "http://localhost:5000/plugins/gce/vms/find",
+}
+
+type DiscoveredVM struct {
+    Name string
+    Address string
+    CanAccessDocker bool
+}
+
+
+func GetCurrentProjectID() (string, error) {
+    request, _ := http.NewRequest(
+        "GET", "http://metadata.google.internal/computeMetadata/v1/project/project-id", nil)
+
+    request.Header.Add("Metadata-Flavor", "Google")
+
+    client := http.Client{}
+    response, err := client.Do(request)
+    if err != nil {
+        return "", err
+    }
+
+    projectID, err := ioutil.ReadAll(response.Body)
+    if err != nil {
+        return "", err
+    }
+    response.Body.Close()
+
+    return string(projectID), nil
+}
+
+func DiscoverVMs(authCode string) {
+    transport := &oauth.Transport{
+        Config: config,
+    }
+    transport.Exchange(authCode)
+
+    computeClient, _ := compute.New(transport.Client())
+
+    projectName, err := GetCurrentProjectID()
+    if err != nil {
+        return
+    }
+
+    zones, _ := computeClient.Instances.AggregatedList(projectName).Do()
+
+    var discoveredVMs []*DiscoveredVM
+
+    for _, zone := range zones.Items {
+        for _, instance := range zone.Instances {
+            // For future reference we need figure out which network interface
+            // to use instead of deafulting to the first one.
+            network := instance.NetworkInterfaces[0]
+
+            discoveredVMs = append(discoveredVMs, &DiscoveredVM{
+                Name: instance.Name,
+                Address: network.NetworkIP,
+                CanAccessDocker: false,
+            })
+            
+        }
+    }
+
+    for _, vm := range discoveredVMs {
+        address := fmt.Sprintf("http://%s:2375/v1/_ping", vm.Address)
+        resp, err := http.Get(address)
+
+        if err == nil {
+            body, _ := ioutil.ReadAll(resp.Body)
+            vm.CanAccessDocker = string(body) == "OK"
+            resp.Body.Close()
+        }
+    }
+
+    data, _ := json.Marshal(discoveredVMs)
+    ioutil.WriteFile("./plugins/gce/vms.json", data, 0664)
+}
+
+func AuthUrl() string {
+    return config.AuthCodeURL("")
+}
+
+func Handle(r *mux.Router) {
+    r.HandleFunc("/vms", func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+
+        vms, err := ioutil.ReadFile("./plugins/gce/vms.json")
+        if err != nil {
+            vms, _ = json.Marshal([]interface{}{})
+        }
+
+        fmt.Fprintf(w, "%s", vms)
+    }).Methods("GET")
+
+    r.HandleFunc("/vms/find", func(w http.ResponseWriter, r *http.Request) {
+        go DiscoverVMs(r.FormValue("code"))
+        http.Redirect(w, r, "/plugins/gce/vms", 302)
+    }).Methods("GET")
+
+    r.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
+        http.Redirect(w, r, AuthUrl(), 302)
+    }).Methods("GET")
+}

--- a/backend/plugins/gce/gce.go
+++ b/backend/plugins/gce/gce.go
@@ -96,10 +96,10 @@ func AuthUrl() string {
 
 func LoadGCEConfig() *oauth.Config {
     var fileName string
-    if _, err := os.Stat("/config/gce.json"); os.IsNotExist(err) {
-        fileName = "../config/gce.json"
+    if _, err := os.Stat("/config/plugins/gce.json"); os.IsNotExist(err) {
+        fileName = "../config/plugins/gce.json"
     } else {
-        fileName = "/config/gce.json"
+        fileName = "/config/plugins/gce.json"
     }
     configFile, _ := ioutil.ReadFile(fileName)
 

--- a/backend/plugins/plugins.go
+++ b/backend/plugins/plugins.go
@@ -1,0 +1,11 @@
+package plugins
+
+import (
+    "./gce"
+
+    "github.com/gorilla/mux"
+)
+
+func Handle(r *mux.Router) {
+    gce.Handle(r.PathPrefix("/gce").Subrouter())
+}

--- a/config/auth.json
+++ b/config/auth.json
@@ -1,0 +1,6 @@
+{
+    "Admins": [
+        {"Email": "admin@gmail.com", "Password": "admin"}
+    ],
+    "SecretKey": "I'm a secret key..."
+}

--- a/config/plugins/gce.json
+++ b/config/plugins/gce.json
@@ -1,0 +1,8 @@
+{
+    "ClientId": "this-is-a-secret",
+    "ClientSecret": "this-is-a-secret",
+    "Scope": "https://www.googleapis.com/auth/compute",
+    "AuthURL": "https://accounts.google.com/o/oauth2/auth",
+    "TokenURL": "https://accounts.google.com/o/oauth2/token",
+    "RedirectURL": "/report/back/to/me/when/authed",
+}

--- a/config/plugins/gce.json
+++ b/config/plugins/gce.json
@@ -4,5 +4,5 @@
     "Scope": "https://www.googleapis.com/auth/compute",
     "AuthURL": "https://accounts.google.com/o/oauth2/auth",
     "TokenURL": "https://accounts.google.com/o/oauth2/token",
-    "RedirectURL": "/report/back/to/me/when/authed",
+    "RedirectURL": "/report/back/to/me/when/authed"
 }


### PR DESCRIPTION
### What
- set up a plugin module for routing request to specific plugins
- created a GCE module for handling GCE specific tasks

Currently lighthouse can detect other vms running inside a GCE project.  Specifically it detects vms that share the same project as itself. 
### Endpoints
- `/plugins/gce/vms` lists all the vms that lighthouse has discovered
- `/plugins/gce/vms/find` tells lighthouse to kick off a task to search for local vms, this requires an authorization code from google to properly run
- `/plugins/gce/authorize` redirects the user to googles gce two-factor login, which in turn once loged in, redirects the user back to our `/plugins/gce/vms/find` with an authorization code
### DiscoveredVM Struct
- **Name**  the name of the vm
- **Address** the internal private ip address of the vm, which is only exposed to other vms sharing the project
- **CanAccessDocker** this tells us whether or not we can access docker on the vm privately, we can detect this by hitting the `/v1/_ping/` endpoint on port 2375.
### Notes

Right now I'm storing data aggregated from the GCE plugin in a JSON file. I'll go through and change it later when we decide on a database.
