### PR TITLE
Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 *.pyc
 *.exe
 *.pem
+
+# Ignore front-end build artifacts
+backend/static
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,14 +53,19 @@ RUN chmod 700 /root/.ssh/id_rsa
 RUN echo "Host github.com\n\tStrictHostKeyChecking no\n" >> /root/.ssh/config
 
 
-# ----- Setup enviroment -----
-RUN git clone git@github.com:ngmiller/lighthouse.git
-WORKDIR /data/lighthouse
-# You can play around with which branch you want the build use. Master is default.
-# RUN git checkout -b some-branch origin/some-branch
+# ----- Setup server enviroment -----
+# change this env variable to support a dev branch
+ENV back-branch master
+ENV front-branch master
 
+# Backend deps
+WORKDIR /data/lighthouse
 RUN go get github.com/fsouza/go-dockerclient
 
+# Frontend deps
 RUN npm install -g gulp
+
+# Command run on container run
+CMD ["/data/lighthouse/getcode.sh"]
 
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,11 +52,13 @@ N2Pt8veiLc0cgXHeGE5rd+zXyeGcmra2W9pfptd49luerYEFQmIC\n\
 RUN chmod 700 /root/.ssh/id_rsa
 RUN echo "Host github.com\n\tStrictHostKeyChecking no\n" >> /root/.ssh/config
 
-
 # ----- Setup server enviroment -----
 # change this env variable to support a dev branch
 ENV back-branch master
 ENV front-branch master
+
+RUN git clone git@github.com:ngmiller/lighthouse.git
+RUN git clone git@github.com:lighthouse/lighthouse-client.git
 
 # Backend deps
 WORKDIR /data/lighthouse
@@ -65,7 +67,6 @@ RUN go get github.com/fsouza/go-dockerclient
 # Frontend deps
 RUN npm install -g gulp
 
+EXPOSE 5000
 # Command run on container run
 CMD ["/data/lighthouse/getcode.sh"]
-
-EXPOSE 5000

--- a/getcode.sh
+++ b/getcode.sh
@@ -14,6 +14,7 @@ git checkout back-branch
 cd /data/lighthouse-client
 git fetch origin
 git checkout front-branch
+npm install
 gulp build
 
 # Run server 

--- a/getcode.sh
+++ b/getcode.sh
@@ -3,14 +3,14 @@
 # Pull backend updates
 cd /data/lighthouse
 git fetch origin
-git checkout back-branch
-git pull origin back-branch
+git checkout $back-branch
+git pull origin $back-branch
 
 # Pull frontend updates and build
 cd /data/lighthouse-client
 git fetch origin
-git checkout front-branch
-git pull origin back-branch
+git checkout $front-branch
+git pull origin $front-branch
 
 npm install
 gulp build

--- a/getcode.sh
+++ b/getcode.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Pull code
+cd /data
+git clone git@github.com:ngmiller/lighthouse.git
+git clone git@github.com:ngmiller/lighthouse-client.git
+
+# Pull backend
+cd /data/lighthouse
+git fetch origin
+git checkout back-branch
+
+# Pull frontend and build
+cd /data/lighthouse-client
+git fetch origin
+git checkout front-branch
+gulp build
+
+# Run server 
+cd /data/lighthouse
+## server commands here

--- a/getcode.sh
+++ b/getcode.sh
@@ -3,7 +3,7 @@
 # Pull code
 cd /data
 git clone git@github.com:ngmiller/lighthouse.git
-git clone git@github.com:ngmiller/lighthouse-client.git
+git clone git@github.com:lighthouse/lighthouse-client.git
 
 # Pull backend
 cd /data/lighthouse

--- a/getcode.sh
+++ b/getcode.sh
@@ -1,22 +1,21 @@
 #!/bin/bash
 
-# Pull code
-cd /data
-git clone git@github.com:ngmiller/lighthouse.git
-git clone git@github.com:lighthouse/lighthouse-client.git
-
-# Pull backend
+# Pull backend updates
 cd /data/lighthouse
 git fetch origin
 git checkout back-branch
+git pull origin back-branch
 
-# Pull frontend and build
+# Pull frontend updates and build
 cd /data/lighthouse-client
 git fetch origin
 git checkout front-branch
+git pull origin back-branch
+
 npm install
 gulp build
 
 # Run server 
-cd /data/lighthouse
-## server commands here
+cd /data/lighthouse/backend/static
+# just testing
+python -m SimpleHTTPServer 5000


### PR DESCRIPTION
https://trello.com/c/tY8JQ56q/44-docker-image-caching-breaks-development-branches

Here's an initial proof of concept as to what the build process could look like. It's currently untested but I just wanted to get things rolling on this.

From our discussion on trello, it seems like the fix for getting image builds to pull a fresh development branch is to have a separate script that clones the repository each time and grabs the specific branches. Since this operation won't be cached, it should reflect any recent changes.

That being said, I think we're looking at the container usage in the wrong way. I think this process slows down the iterative developments efforts I'd like to see when working on the front-end. The container build and run should really only be used when we're ready to actually deploy. From a development perspective, I should be able to just fire up the server locally (i.e. not in a docker instance), make some changes to the front-end, re-run gulp and see the changes instantly, without having to first (1) push changes to github (which requires a commit), and (2) restart some running container.

For a little more rigorous integration tests, it would be worthwhile going through the container build. And for that reason, we'll still need to pull in specific development branches.

I decided to put the front-end into a separate repo to facilitate testing. (with this, we could test two outstanding development branches simultaneously)
