### PR TITLE
Revised url prefix for login/logout to "/api/v0.1"

### DIFF
--- a/lighthouse.go
+++ b/lighthouse.go
@@ -81,7 +81,7 @@ func main() {
     dockerRouter  := hostRouter.PathPrefix("/d").Methods("GET", "POST", "PUT", "DELETE").Subrouter()
     dockerRouter.HandleFunc("/{DockerURL:.*}", DockerHandler)
 
-    provider.Handle(baseRouter.PathPrefix("/provider").Subrouter())
+    provider.Handle(versionRouter.PathPrefix("/provider").Subrouter())
 
     auth.Handle(versionRouter)
 


### PR DESCRIPTION
![screen shot 2014-11-20 at 8 50 36 am](https://cloud.githubusercontent.com/assets/1557523/5126408/608e35ca-7092-11e4-9e71-815b60ddd12f.png)
