### PR TITLE
Fix Routing to Handle Endpoints Persisted by Client

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -134,6 +134,12 @@ func Handle(r *mux.Router) {
 
         session.Save("auth", r, w)
 
+        if userOK && passwordOK {
+            w.WriteHeader(200)
+        } else {
+            w.WriteHeader(401)
+        }
+
         fmt.Fprintf(w, "%t", userOK && passwordOK)
     }).Methods("POST")
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -92,10 +92,10 @@ func AuthMiddleware(h http.Handler, ignorePaths []string) http.Handler {
 
         if loggedIn := session.GetValueOrDefault(r, "auth", "logged_in", false).(bool); loggedIn {
             h.ServeHTTP(w, r)
-        } else {
-            w.WriteHeader(http.StatusUnauthorized)
-            fmt.Fprintf(w, "unauthorized")
+            return
         }
+
+        http.Redirect(w, r, "/login",  http.StatusFound)
     })
 }
 

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -32,14 +32,18 @@ const (
     API_VERSION_0_1 = "/api/v0.1"
 )
 
+func ServeIndex(w http.ResponseWriter, r *http.Request) {
+    http.ServeFile(w, r, "static/index.html")
+}
+
+
 func main() {
 
     logging.Info("Starting...")
     baseRouter := mux.NewRouter()
 
-    baseRouter.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-        http.ServeFile(w, r, "static/index.html")
-    }).Methods("GET")
+    baseRouter.HandleFunc("/", ServeIndex).Methods("GET")
+    baseRouter.NotFoundHandler =  http.HandlerFunc(ServeIndex)
 
     staticServer := http.FileServer(http.Dir("static"))
     baseRouter.PathPrefix("/static/").Handler(
@@ -59,6 +63,7 @@ func main() {
 
     ignoreURLs := []string{
         "/",
+        "/login",
         fmt.Sprintf("%s/login", API_VERSION_0_1),
         fmt.Sprintf("%s/logout", API_VERSION_0_1),
     }


### PR DESCRIPTION
## What
- If the user is unauthorized they will be redirected to `/login`.
- If a login fails a `401` status code is returned.
- If a url persisted by the client is found & and the user is authenticated serve `index.html`.
