### PR TITLE
Update Postgres Accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,30 @@ Lighthouse
 
 It bridges the gap between providers hosting docker services. Are you running containers accross hundreds of vms across the world wide web? No problem, Lighthouse gives you the power to manage and maintain those vms with a few simple clicks. Everything was built with the goal of monotizing AWS, GCE, Azure, ect. into an easy to manage platform.
 
-### Build and Deploy
-
-* `git clone git@github.com:lighthouse/lighthouse.git`
-* (optional) `git clone git@github.com:lighthouse/lighthouse-client.git && cd lighthouse-client`
-* (optional) `gulp prod build && cd ..`
-* `docker build -t lighthouse .`
-* `docker run --name postgres-image -d postgres`
-* `docker run -t -i -p 5000:5000 --link postgres-image:postgres lighthouse`
-
-The optional commands above will grab and build the web app frontend if you desire such functionality. Otherwise, see the API documentation for more information.
-
 ### Dependencies
 
 * [golang](https://golang.org/)
 * a Docker instance if running locally. [boot2docker](http://boot2docker.io/) works well for Windows or OS X
 * see [lighthouse-client](https://github.com/lighthouse/lighthouse-client) for set up if opting to use web client
+* (optional) [PostgresSQL](http://www.postgresql.org/)
+
+### Build & Run
+
+* `go get github.com/lighthouse/lighthouse`
+* (optional) build a static client into the root directory named `static`, see [lighthouse-client](https://github.com/lighthouse/lighthouse-client) for more information
+* Run postgres locally or inside boot2docker
+  * `docker run -p 5432:5432 -d postgres:latest`
+  * See more about running PostgresSQL locally [here](http://www.postgresql.org/docs/9.1/static/tutorial-start.html) if you don't want to use docker
+* `$GOPATH/bin/lighthouse`
+
+### Build & Run W/ Docker
+
+* `go get github.com/lighthouse/lighthouse`
+* (optional) build a static client into the root directory named `static`, see [lighthouse-client](https://github.com/lighthouse/lighthouse-client) for more information
+* `cd $GOPATH/src/github.com/lighthouse/lighthouse`
+* `docker build -t lighthouse .`
+* `docker run --name postgres-image -d postgres:latest`
+* `docker run -t -i --rm -p 5000:5000 --link postgres-image:postgres lighthouse`
 
 ### API
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It bridges the gap between providers hosting docker services. Are you running co
 
 * `go get github.com/lighthouse/lighthouse`
 * (optional) build a static client into the root directory named `static`, see [lighthouse-client](https://github.com/lighthouse/lighthouse-client) for more information
+* `cd $GOPATH/src/github.com/lighthouse/lighthouse`
 * Run postgres locally or inside boot2docker
   * `docker run -p 5432:5432 -d postgres:latest`
   * See more about running PostgresSQL locally [here](http://www.postgresql.org/docs/9.1/static/tutorial-start.html) if you don't want to use docker

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -74,7 +74,11 @@ func connect() *sql.DB {
     postgres, err := sql.Open("postgres", postgresOptions)
 
     if err != nil {
-        fmt.Println(err.Error())
+        panic(err.Error())
+    }
+
+    if err := postgres.Ping(); err != nil {
+        panic(err.Error())
     }
 
     return postgres

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -17,6 +17,7 @@ package postgres
 import (
     "os"
     "fmt"
+    "strings"
     "errors"
     "encoding/json"
 
@@ -24,6 +25,8 @@ import (
     "database/sql/driver"
 
     _ "github.com/lib/pq"
+
+    "github.com/lighthouse/lighthouse/logging"
 )
 
 type DBInterface interface {
@@ -61,14 +64,28 @@ func NewFromDB(table string, db DBInterface) *Database {
 }
 
 func connect() *sql.DB {
-    host := os.Getenv("POSTGRES_PORT_5432_TCP_ADDR")
+    postgresHost := os.Getenv("POSTGRES_PORT_5432_TCP_ADDR")
+    dockerHost := os.Getenv("DOCKER_HOST")
+
     var postgresOptions string
 
-    if host == "" { // if running locally
-        postgresOptions = "sslmode=disable"
-    } else { // if running in docker
+    if postgresHost != "" {
+        logging.Info("connecting to a linked container running postgres")
+
         postgresOptions = fmt.Sprintf(
-            "host=%s sslmode=disable user=postgres", host)
+            "host=%s sslmode=disable user=postgres", postgresHost)
+
+    } else if dockerHost != "" {
+        logging.Info("connecting to postgres server inside a docker container")
+
+        dockerHost = strings.Replace(dockerHost, "tcp://", "", 1)
+        dockerHost = strings.Split(dockerHost, ":")[0]
+
+        postgresOptions = fmt.Sprintf(
+                "host=%s sslmode=disable user=postgres", dockerHost)
+    } else {
+        logging.Info("connecting to localhost running postgres")
+        postgresOptions = "sslmode=disable"
     }
 
     postgres, err := sql.Open("postgres", postgresOptions)


### PR DESCRIPTION
## What

Lighthouse can now connect to Postgres in 3 different ways.  Lighthouse now panics if connection to the database fails, because I'm tired of the Lighthouse silently failing.
### Lighthouse Inside Docker
- run database in docker container 
  - `docker run --name postgres-image -d postgres:latest`
  - `docker run -t -i --rm -p 5000:5000 --link postgres-image:postgres lighthouse`
### Lighthouse Outside Docker
- run database on localhost
  - read more [here](http://www.postgresql.org/docs/9.1/static/server-start.html)
  - `$GOPATH/bin/lighthouse`
- run database in docker container 
  - `docker run -p 5432:5432 -d postgres:latest`
  - `$GOPATH/bin/lighthouse`
