### PR TITLE
Fixed query param forwarding

### DIFF
--- a/handlers/docker_request_handler.go
+++ b/handlers/docker_request_handler.go
@@ -35,6 +35,10 @@ import (
 func DockerRequestHandler(w http.ResponseWriter, info HandlerInfo) *HandlerError {
     url := "http://" + info.Host + "/" + info.DockerEndpoint
 
+    if info.Request.URL.RawQuery != "" {
+        url += "?" + info.Request.URL.RawQuery
+    }
+
     payload := []byte(nil)
     if info.Body != nil {
         payload = []byte(info.Body.Payload)

--- a/handlers/docker_request_handler_test.go
+++ b/handlers/docker_request_handler_test.go
@@ -83,6 +83,38 @@ func Test_DockerRequestHandler_GET(t *testing.T) {
 }
 
 /*
+    Tests docker request forwarding requests with query params
+*/
+func Test_DockerRequestHandler_query_params(t *testing.T) {
+    h :=  func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(200)
+
+        assert.Equal(t, "test=pass", r.URL.RawQuery,
+            "DockerRequestHandler should forwarded request's query params.")
+
+        w.Write([]byte("success"))
+    }
+
+    defer SetupServer(&h).Close()
+
+    w := httptest.NewRecorder()
+    r, _ := http.NewRequest("GET", "/?test=pass", nil)
+    info := HandlerInfo{"", "localhost:8080", nil, r}
+
+    err := DockerRequestHandler(w, info)
+
+    assert.Nil(t, err, "DockerRequestHandler should return nil error on valid request")
+
+    assert.Equal(t, 200, w.Code,
+        "DockerRequestHandler should output the forwarded request's response code.")
+
+    body, _ := ioutil.ReadAll(w.Body)
+
+    assert.Equal(t, "success", string(body),
+        "DockerRequestHandler should output the forwarded request's response body.")
+}
+
+/*
     Tests docker request forwarding for bodied requests
     Purpose: POST and PUT requests
 */


### PR DESCRIPTION
This should solve the issue of query parameter forwarding over Docker requests.

Unfortunately mux doesn't make them very available like it does with its URL parameters, so I had to dig into the actual request a little.

Added a unit test to make up for it :)
