### PR TITLE
Generic URI extraction

### DIFF
--- a/handlers/docker/docker.go
+++ b/handlers/docker/docker.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package handlers
+package docker
 
 import (
     "fmt"
@@ -20,8 +20,11 @@ import (
     "io/ioutil"
     "bytes"
 
+    "github.com/gorilla/mux"
+
     "github.com/lighthouse/lighthouse/session"
     "github.com/lighthouse/lighthouse/beacons"
+    "github.com/lighthouse/lighthouse/handlers"
 )
 
 /*
@@ -30,9 +33,9 @@ import (
 
     Will only write to the given ResponseWriter on success.
 
-    RETURN: nil on succes.  A non-nil *HandlerError on failure
+    RETURN: nil on succes.  A non-nil *handlers.HandlerError on failure
 */
-func DockerRequestHandler(w http.ResponseWriter, info HandlerInfo) *HandlerError {
+func DockerRequestHandler(w http.ResponseWriter, info handlers.HandlerInfo) *handlers.HandlerError {
     email := session.GetValueOrDefault(info.Request, "auth", "email", "").(string)
     beaconInstance, err := beacons.GetBeacon(info.Host)
 
@@ -63,7 +66,7 @@ func DockerRequestHandler(w http.ResponseWriter, info HandlerInfo) *HandlerError
 
     req, err := http.NewRequest(method, url, bytes.NewBuffer(payload))
     if err != nil {
-        return &HandlerError{500, "control", "Failed to create " + method + " request"}
+        return &handlers.HandlerError{500, "control", "Failed to create " + method + " request"}
     }
 
     if requestIsToBeacon && beaconInstance.Users[email] {
@@ -72,19 +75,19 @@ func DockerRequestHandler(w http.ResponseWriter, info HandlerInfo) *HandlerError
 
     resp, err := http.DefaultClient.Do(req)
     if err != nil {
-        return &HandlerError{500, "control", method + " request failed"}
+        return &handlers.HandlerError{500, "control", method + " request failed"}
     }
 
     // Close body after return
     defer resp.Body.Close()
 
     if resp.StatusCode > 299 {
-        return &HandlerError{resp.StatusCode, "docker", resp.Status}
+        return &handlers.HandlerError{resp.StatusCode, "docker", resp.Status}
     }
 
     body, err := ioutil.ReadAll(resp.Body)
     if err != nil {
-        return &HandlerError{500, "control", "Failed reading response body"}
+        return &handlers.HandlerError{500, "control", "Failed reading response body"}
     }
 
     w.WriteHeader(resp.StatusCode)
@@ -103,13 +106,21 @@ func DockerHandler(w http.ResponseWriter, r *http.Request) {
     // Ready all HTTP form data for the handlers
     r.ParseForm()
 
-    info := GetHandlerInfo(r)
+    info, ok := handlers.GetHandlerInfo(r)
 
-    var customHandlers = CustomHandlerMap{
+    if !ok {
+        handlers.WriteError(w, handlers.HandlerError {
+            http.StatusBadRequest, 
+            "control", "could not get required data for handler",
+        })
+        return
+    }
+
+    var customHandlers = handlers.CustomHandlerMap{
         //regexp.MustCompile("example"): ExampleHandler,
     }
 
-    runCustomHandlers, err := RunCustomHandlers(info, customHandlers)
+    runCustomHandlers, err := handlers.RunCustomHandlers(info, customHandlers)
 
     // On success, send request to Docker
     if err == nil {
@@ -118,6 +129,10 @@ func DockerHandler(w http.ResponseWriter, r *http.Request) {
 
     // On error, rollback
     if err != nil {
-        Rollback(w, *err, info, runCustomHandlers)
+        handlers.Rollback(w, *err, info, runCustomHandlers)
     }
+}
+
+func Handle(r *mux.Router) {
+    r.HandleFunc("/{Endpoint:.*}", DockerHandler)
 }

--- a/handlers/docker/docker_test.go
+++ b/handlers/docker/docker_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package handlers
+package docker
 
 import (
     "testing"
@@ -26,6 +26,7 @@ import (
 
     "github.com/lighthouse/lighthouse/databases"
     "github.com/lighthouse/lighthouse/beacons"
+    "github.com/lighthouse/lighthouse/handlers"
 )
 
 /*
@@ -75,7 +76,7 @@ func Test_DockerRequestHandler_GET(t *testing.T) {
 
     w := httptest.NewRecorder()
     r, _ := http.NewRequest("GET", "/", nil)
-    info := HandlerInfo{"", "localhost:8080", nil, r}
+    info := handlers.HandlerInfo{"", "localhost:8080", nil, r}
 
     err := DockerRequestHandler(w, info)
 
@@ -110,7 +111,7 @@ func Test_DockerRequestHandler_query_params(t *testing.T) {
 
     w := httptest.NewRecorder()
     r, _ := http.NewRequest("GET", "/?test=pass", nil)
-    info := HandlerInfo{"", "localhost:8080", nil, r}
+    info := handlers.HandlerInfo{"", "localhost:8080", nil, r}
 
     err := DockerRequestHandler(w, info)
 
@@ -148,7 +149,7 @@ func Test_DockerRequestHandler_POST(t *testing.T) {
 
     w := httptest.NewRecorder()
     r, _ := http.NewRequest("POST", "/", bytes.NewBuffer(testBody))
-    info := HandlerInfo{"", "localhost:8080", &RequestBody{string(testBody)}, r}
+    info := handlers.HandlerInfo{"", "localhost:8080", &handlers.RequestBody{string(testBody)}, r}
 
     err := DockerRequestHandler(w, info)
 
@@ -173,7 +174,7 @@ func Test_DockerRequestHandler_BadEndpoint(t *testing.T) {
 
     w := httptest.NewRecorder()
     r, _ := http.NewRequest("GET", "/", nil)
-    info := HandlerInfo{"", "localhost:8080", nil, r}
+    info := handlers.HandlerInfo{"", "localhost:8080", nil, r}
 
     err := DockerRequestHandler(w, info)
 
@@ -203,7 +204,7 @@ func Test_DockerRequestHandler_ServerError(t *testing.T) {
 
     w := httptest.NewRecorder()
     r, _ := http.NewRequest("GET", "/", nil)
-    info := HandlerInfo{"", "localhost:8080", nil, r}
+    info := handlers.HandlerInfo{"", "localhost:8080", nil, r}
 
     err := DockerRequestHandler(w, info)
 
@@ -233,7 +234,7 @@ func Test_DockerRequestHandler_NilResponseBody(t *testing.T) {
 
     w := httptest.NewRecorder()
     r, _ := http.NewRequest("GET", "/", nil)
-    info := HandlerInfo{"", "localhost:8080", nil, r}
+    info := handlers.HandlerInfo{"", "localhost:8080", nil, r}
 
     err := DockerRequestHandler(w, info)
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -17,17 +17,16 @@ package handlers
 import (
     "testing"
     "net/http"
+    "strings"
     "net/http/httptest"
     "bytes"
     "io/ioutil"
-    "strings"
     "regexp"
 
     "github.com/gorilla/mux"
     "github.com/stretchr/testify/assert"
 
     "github.com/lighthouse/lighthouse/beacons/aliases"
-
     "github.com/lighthouse/lighthouse/databases"
 )
 
@@ -106,15 +105,17 @@ func Test_GetHandlerInfo(t *testing.T) {
     router := mux.NewRouter()
     var info HandlerInfo
 
-    router.HandleFunc("/{Host}/{DockerURL}",
+    router.HandleFunc("/{Endpoint:.*}",
         func(w http.ResponseWriter, r *http.Request) {
-            info = GetHandlerInfo(r)
+            info, _ = GetHandlerInfo(r)
     })
 
-    r, _ := http.NewRequest("GET", "/TestHost/TestEndpoint", nil)
+    r, _ := http.NewRequest("GET", "/TestHost/Test%2FEndpoint", nil)
+    r.RequestURI = "/TestHost/Test%2FEndpoint"
+
     router.ServeHTTP(httptest.NewRecorder(), r)
 
-    expected := HandlerInfo{"TestEndpoint", "TestHost", nil, r}
+    expected := HandlerInfo{"Test/Endpoint", "TestHost", nil, r}
 
     assert.Equal(t, expected, info,
         "GetHandlerInfo did not extract data correctly")

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -20,10 +20,10 @@ import (
 
     "github.com/lighthouse/lighthouse/auth"
     "github.com/lighthouse/lighthouse/provider"
-    "github.com/lighthouse/lighthouse/handlers"
     "github.com/lighthouse/lighthouse/beacons"
     "github.com/lighthouse/lighthouse/beacons/aliases"
     "github.com/lighthouse/lighthouse/users"
+    "github.com/lighthouse/lighthouse/handlers/docker"
 
     "github.com/lighthouse/lighthouse/logging"
 
@@ -37,7 +37,6 @@ const (
 func ServeIndex(w http.ResponseWriter, r *http.Request) {
     http.ServeFile(w, r, "static/index.html")
 }
-
 
 func main() {
 
@@ -58,11 +57,7 @@ func main() {
 
     versionRouter := baseRouter.PathPrefix(API_VERSION_0_2).Subrouter()
 
-    dockerRouter := versionRouter.PathPrefix("/d")
-    hostRouter := dockerRouter.PathPrefix("/{Host}").Methods("GET", "POST", "PUT", "DELETE").Subrouter()
-    hostRouter.HandleFunc("/{DockerURL:.*}", handlers.DockerHandler)
-
-
+    docker.Handle(versionRouter.PathPrefix("/d").Subrouter())
     provider.Handle(versionRouter.PathPrefix("/provider").Subrouter())
     beacons.Handle(versionRouter.PathPrefix("/beacons").Subrouter())
     auth.Handle(versionRouter)

--- a/session/session.go
+++ b/session/session.go
@@ -23,7 +23,13 @@ import (
 
 var cookieStore = sessions.NewCookieStore(securecookie.GenerateRandomKey(32))
 
-func GetValueOrDefault(r *http.Request, sessionKey, key string, def interface{}) interface{} {
+func GetValueOK(r *http.Request, sessionKey string, key interface{}) (interface{}, bool) {
+    session := GetSession(r, sessionKey)
+    val, ok := session.Values[key]
+    return val, ok
+}
+
+func GetValueOrDefault(r *http.Request, sessionKey string, key, def interface{}) interface{} {
     session := GetSession(r, sessionKey)
     val, ok := session.Values[key]
     if ok {
@@ -32,7 +38,7 @@ func GetValueOrDefault(r *http.Request, sessionKey, key string, def interface{})
     return def
 }
 
-func SetValue(r *http.Request, sessionKey, key string, value interface{}) {
+func SetValue(r *http.Request, sessionKey string, key, value interface{}) {
     session := GetSession(r, sessionKey)
     session.Values[key] = value
 }


### PR DESCRIPTION
## What

Fix for [the URI encoding issue](https://github.com/lighthouse/lighthouse/issues/30).
## Why

So that URL parameters such as hosts can be URI encoded and captured correctly.
## How

There are a few endpoint changes to support it (in code only, the API remains unchanged).  The focus of the fix is the addition of the `GetEndpointParams()` function in `handlers/handlers.go`.

---

The rest of this comment is simply documentation on this function for future use.

`GetEndpointParams()` takes an `*http.Request` and `[]string` and returns a `map[string]string`.  The values of the array are used as keys in the map and parallel the endpoint itself.

To use this function, mux must have a `"Endpoint"` route variable (`r.HandleFunc("/prefix/{Endpoint:.*}", ...`)

The endpoint is broken by `/`s and the map is filled until either the array or the endpoint runs out of new values.  If the array runs out first, the rest of the endpoint is placed into the last key in the array.  If the endpoint runs out first, the remaining keys in the array are ignore (this lets you perform size checks).
### Examples

**Normal case**

``` json
Endpoint:  /d/127.0.0.1%2Fv1.12/info
Key array: [ "Host", "Endpoint" ]
Result:    { "Host" : "127.0.0.1/v1.12", "Endpoint" : "info" }
```

**Not enough keys**

``` json
Endpoint:  /d/127.0.0.1%2Fv1.12/containers/json
Key array: [ "Host", "Endpoint" ]
Result:    { "Host" : "127.0.0.1/v1.12", "Endpoint" : "containers/json" }
```

**Too many keys**

``` json
Endpoint:  /d/127.0.0.1%2Fv1.12/info
Key array: [ "Host", "Endpoint", "ExtraKey" ]
Result:    { "Host" : "127.0.0.1/v1.12", "Endpoint" : "info" }
```
