### PR TITLE
/whoami endpoint

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -95,7 +95,7 @@ func AuthMiddleware(h http.Handler, ignorePaths []string) http.Handler {
             return
         }
 
-        http.Redirect(w, r, "/login",  http.StatusFound)
+        w.WriteHeader(401)
     })
 }
 
@@ -146,5 +146,17 @@ func Handle(r *mux.Router) {
     r.HandleFunc("/logout", func(w http.ResponseWriter, r *http.Request) {
         session.SetValue(r, "auth", "logged_in", false)
         session.Save("auth", r, w)
+    }).Methods("GET")
+
+    r.HandleFunc("/whoami", func(w http.ResponseWriter, r *http.Request) {
+        email, loggedIn := session.GetValueOK(r, "auth", "email")
+
+        if loggedIn {
+            w.WriteHeader(200)
+            fmt.Fprintf(w, "%s", email)
+        } else {        
+            w.WriteHeader(404)    
+        }        
+
     }).Methods("GET")
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -35,18 +35,6 @@ func Test_SaltPassword(t *testing.T) {
     assert.Equal(t, expectedResult, SaltPassword("12345", "i'm the salt"))
 }
 
-func Test_WhoAmI_NotLoggedIn(t *testing.T) {
-	r, _ := http.NewRequest("GET", "/whoami", nil)
-
-    m := mux.NewRouter()
-    Handle(m)	
-    w := httptest.NewRecorder()
-
-    m.ServeHTTP(w, r)
-
-    assert.Equal(t, 404, w.Code)
-}
-
 func Test_WhoAmI_LoggedIn(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/whoami", nil)
     session.SetValue(r, "auth", "email", "TEST_EMAIL")

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -18,7 +18,14 @@ package auth
 import (
     "testing"
 
+    "net/http"
+    "net/http/httptest"
+
     "github.com/stretchr/testify/assert"
+
+    "github.com/gorilla/mux"
+
+    "github.com/lighthouse/lighthouse/session"
 )
 
 
@@ -26,4 +33,42 @@ func Test_SaltPassword(t *testing.T) {
     SECRET_HASH_KEY = "i'm the secret hash key"
     expectedResult := "00a987631776516d7dd00e8ace06c5c5a83739dbf95742ddf5f39eeda1f26c346f235131b4bc1a1eb244d479f899610f420e23cefb139d47c0d9a07ed1bf909c"
     assert.Equal(t, expectedResult, SaltPassword("12345", "i'm the salt"))
+}
+
+func Test_WhoAmI_NotLoggedIn(t *testing.T) {
+	r, _ := http.NewRequest("GET", "/whoami", nil)
+
+    m := mux.NewRouter()
+    Handle(m)	
+    w := httptest.NewRecorder()
+
+    m.ServeHTTP(w, r)
+
+    assert.Equal(t, 404, w.Code)
+}
+
+func Test_WhoAmI_LoggedIn(t *testing.T) {
+	r, _ := http.NewRequest("GET", "/whoami", nil)
+    session.SetValue(r, "auth", "email", "TEST_EMAIL")
+
+    m := mux.NewRouter()
+    Handle(m)	
+    w := httptest.NewRecorder()
+
+    m.ServeHTTP(w, r)
+
+    assert.Equal(t, 200, w.Code)
+    assert.Equal(t, "TEST_EMAIL", w.Body.String())
+}
+
+func Test_WhoAmI_NotLoggedIn(t *testing.T) {
+	r, _ := http.NewRequest("GET", "/whoami", nil)
+
+    m := mux.NewRouter()
+    Handle(m)	
+    w := httptest.NewRecorder()
+
+    m.ServeHTTP(w, r)
+
+    assert.Equal(t, 404, w.Code)
 }

--- a/config/beacon_permissions.json
+++ b/config/beacon_permissions.json
@@ -1,20 +1,3 @@
 {
-	"Beacons" :
-	[
-		{
-			"Address" : "127.0.0.1:5002",
-			"Token" : "TOKEN",
-			"Users" : {"admin@gmail.com":true}
-		}
-	],
 
-	"Instances" :
-	[
-		{
-			"InstanceAddress" : "127.0.0.1:5001/v1.12",
-			"Name" : "boot2docker",
-			"CanAccessDocker" : true,
-			"BeaconAddress" : "127.0.0.1:5002"
-		}
-	]
 }

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -66,6 +66,7 @@ func main() {
         "/login",
         fmt.Sprintf("%s/login", API_VERSION_0_2),
         fmt.Sprintf("%s/logout", API_VERSION_0_2),
+        fmt.Sprintf("%s/whoami", API_VERSION_0_2),
     }
 
     app := auth.AuthMiddleware(baseRouter, ignoreURLs)


### PR DESCRIPTION
## What

Added a `/whoami` endpoint to the auth handlers.
## Why

Lets the frontend check that someone is actually logged in to detect Lighthouse restarting and other auth failures.
## Endpoints

``` http
GET /whoami HTTP/1.1
```
### Examples

**Someone is logged in:**

``` http
HTTP/1.1 200 OK
admin@gmail.com
```

**Someone is not logged in:**

``` http
HTTP/1.1 404 Not Found
```
