### PR TITLE
Better database errors

### DIFF
--- a/beacons/handlers.go
+++ b/beacons/handlers.go
@@ -44,7 +44,8 @@ func writeResponse(err error, w http.ResponseWriter) {
 
     switch err {
         case databases.KeyNotFoundError, databases.NoUpdateError, 
-                databases.EmptyKeyError, NotEnoughParametersError:
+                databases.EmptyKeyError, databases.DuplicateKeyError,
+                NotEnoughParametersError:
             code = http.StatusBadRequest
 
         case nil:
@@ -149,8 +150,6 @@ func handleBeaconCreate(w http.ResponseWriter, r *http.Request) {
     if err != nil {
         return
     }
-
-    fmt.Println(beaconInfo.Address, beaconInfo.Alias)
 
     if beaconInfo.Address == "" || beaconInfo.Alias == "" {
         err = NotEnoughParametersError

--- a/databases/databases.go
+++ b/databases/databases.go
@@ -23,6 +23,8 @@ import (
     "encoding/json"
 
     "database/sql"
+
+    "github.com/lighthouse/lighthouse/logging"
 )
 
 var (
@@ -31,6 +33,7 @@ var (
     UnknownError = errors.New("databases: unknown error")
     KeyNotFoundError = errors.New("databases: given key not found")
     NoRowsError = errors.New("databases: result was empty")
+    DuplicateKeyError = errors.New("databases: key already exists")
 )
 
 type Table struct {
@@ -149,7 +152,7 @@ func (this *Table) Insert(key string, value interface{}) error {
     _, err := this.db.Exec(query, key, string(json))
 
     if err != nil {
-        fmt.Println(err.Error())
+        logging.Info(err.Error())
     }
     return err
 }
@@ -187,7 +190,7 @@ func (this *Table) InsertSchema(values map[string]interface{}) error {
     }
 
     if err != nil {
-        fmt.Println(err.Error())
+        logging.Info(err.Error())
     }
     return err
 }
@@ -200,7 +203,7 @@ func (this *Table) Update(key string, newValue interface{}) (error) {
     _, err := this.db.Exec(query, key, string(json))
 
     if err != nil {
-        fmt.Println(err.Error())
+        logging.Info(err.Error())
     }
     return err
 }
@@ -259,7 +262,7 @@ func (this *Table) UpdateSchema(to, where map[string]interface{}) (error) {
     }
 
     if err != nil {
-        fmt.Println(err.Error())
+        logging.Info(err.Error())
     }
     return err
 }

--- a/databases/postgres/postgres.go
+++ b/databases/postgres/postgres.go
@@ -21,21 +21,44 @@ import (
 
     "database/sql"
 
-    _ "github.com/lib/pq"
+    "github.com/lib/pq"
 
     "github.com/lighthouse/lighthouse/logging"
+
+    "github.com/lighthouse/lighthouse/databases"
 )
 
-var connection *sql.DB
+type postgresConnection struct {
+    sql.DB
+}
 
-func Connection() *sql.DB {
+var connection *postgresConnection
+
+func Connection() databases.DBInterface {
     if connection == nil {
         connection = setup()
     }
     return connection
 }
 
-func setup() *sql.DB {
+func (this *postgresConnection) Exec(cmd string, params ...interface{}) (sql.Result, error) {
+    res, err := this.DB.Exec(cmd, params...)
+    
+    if err != nil {
+        pqErr, ok := err.(*pq.Error)
+
+        if ok {
+            switch pqErr.Code {
+            case "23505": 
+                err = databases.DuplicateKeyError
+            }
+        }
+    }
+
+    return res, err
+}
+
+func setup() *postgresConnection {
     postgresHost := os.Getenv("POSTGRES_PORT_5432_TCP_ADDR")
     dockerHost := os.Getenv("DOCKER_HOST")
 
@@ -70,5 +93,5 @@ func setup() *sql.DB {
         panic(err.Error())
     }
 
-    return postgres
+    return &postgresConnection{*postgres}
 }


### PR DESCRIPTION
## What

Extended the postgres package to capture pq Errors and turn them into database errors
## Why

Allows database users to not have to care about what driver is being used for error checking.  All errors should either be SQL or database types.
## How

postgres catches errors and checks if it is a pq.Error.  If it is, it simply swaps out that error for a better (more user friendly) one.
