### PR TITLE
Ensure content type is application/json

### DIFF
--- a/handlers/docker/docker.go
+++ b/handlers/docker/docker.go
@@ -71,6 +71,8 @@ func DockerRequestHandler(w http.ResponseWriter, info handlers.HandlerInfo) *han
         req.Header.Set(beacons.HEADER_TOKEN_KEY, token)
     }
 
+    // Ensure Content-Type
+    req.Header.Set("Content-Type", "application/json")
     resp, err := http.DefaultClient.Do(req)
     if err != nil {
         return &handlers.HandlerError{500, "control", method + " request failed"}

--- a/handlers/docker/docker.go
+++ b/handlers/docker/docker.go
@@ -72,7 +72,13 @@ func DockerRequestHandler(w http.ResponseWriter, info handlers.HandlerInfo) *han
     }
 
     // Ensure Content-Type
-    req.Header.Set("Content-Type", "application/json")
+    contentType := info.Request.Header.Get("Content-Type")
+    if contentType != "" {
+        req.Header.Set("Content-Type", contentType)
+    } else {
+        req.Header.Set("Content-Type", "application/json")
+    }
+    
     resp, err := http.DefaultClient.Do(req)
     if err != nil {
         return &handlers.HandlerError{500, "control", method + " request failed"}


### PR DESCRIPTION
When testing container creates, I found that lighthouse is either stripping the `Content-Type` header or simply not setting it. This results in a 500 response code from the targeted docker instance.
