### PR TITLE
Backend error standardization

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -95,7 +95,7 @@ func AuthMiddleware(h http.Handler, ignorePaths []string) http.Handler {
             return
         }
 
-        if strings.Contains("/api", r.URL.Path) {
+        if strings.HasPrefix(r.URL.Path, "/api") {
             w.WriteHeader(401)
         } else {
             http.Redirect(w, r, "/", http.StatusFound)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -95,7 +95,7 @@ func AuthMiddleware(h http.Handler, ignorePaths []string) http.Handler {
             return
         }
 
-        w.WriteHeader(404)
+        http.Redirect(w, r, "/", http.StatusFound)
     })
 }
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -143,8 +143,6 @@ func Handle(r *mux.Router) {
         } else {
             handlers.WriteError(w, 401, "auth", "email or password incorrect")
         }
-
-        fmt.Fprintf(w, "%t", userOK && passwordOK)
     }).Methods("POST")
 
     r.HandleFunc("/logout", func(w http.ResponseWriter, r *http.Request) {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -95,7 +95,11 @@ func AuthMiddleware(h http.Handler, ignorePaths []string) http.Handler {
             return
         }
 
-        http.Redirect(w, r, "/", http.StatusFound)
+        if strings.Contains("/api", r.URL.Path) {
+            http.WriteHeader(401)
+        } else {
+            http.Redirect(w, r, "/", http.StatusFound)
+        }
     })
 }
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -96,7 +96,7 @@ func AuthMiddleware(h http.Handler, ignorePaths []string) http.Handler {
         }
 
         if strings.Contains("/api", r.URL.Path) {
-            http.WriteHeader(401)
+            w.WriteHeader(401)
         } else {
             http.Redirect(w, r, "/", http.StatusFound)
         }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -30,7 +30,7 @@ import (
     "github.com/gorilla/mux"
 
     "github.com/lighthouse/lighthouse/users"
-
+    "github.com/lighthouse/lighthouse/handlers"
     "github.com/lighthouse/lighthouse/session"
 )
 
@@ -96,7 +96,7 @@ func AuthMiddleware(h http.Handler, ignorePaths []string) http.Handler {
         }
 
         if strings.HasPrefix(r.URL.Path, "/api") {
-            w.WriteHeader(401)
+            handlers.WriteError(w, 401, "auth", "not logged in")
         } else {
             http.Redirect(w, r, "/", http.StatusFound)
         }
@@ -141,7 +141,7 @@ func Handle(r *mux.Router) {
         if userOK && passwordOK {
             w.WriteHeader(200)
         } else {
-            w.WriteHeader(401)
+            handlers.WriteError(w, 401, "auth", "email or password incorrect")
         }
 
         fmt.Fprintf(w, "%t", userOK && passwordOK)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -90,12 +90,12 @@ func AuthMiddleware(h http.Handler, ignorePaths []string) http.Handler {
             }
         }
 
-        if loggedIn := session.GetValueOrDefault(r, "auth", "logged_in", false).(bool); loggedIn {
+        if session.GetValueOrDefault(r, "auth", "logged_in", false).(bool) {
             h.ServeHTTP(w, r)
             return
         }
 
-        http.Redirect(w, r, "/login",  http.StatusFound)
+        w.WriteHeader(404)
     })
 }
 

--- a/beacons/aliases/aliases.go
+++ b/beacons/aliases/aliases.go
@@ -16,7 +16,6 @@ package aliases
 
 import (
     "os"
-    "fmt"
     "io/ioutil"
     "net/http"
 
@@ -24,6 +23,7 @@ import (
 
     "github.com/gorilla/mux"
 
+    "github.com/lighthouse/lighthouse/handlers"
     "github.com/lighthouse/lighthouse/databases"
     "github.com/lighthouse/lighthouse/databases/postgres"
 )
@@ -144,9 +144,10 @@ func handleUpdateAlias(w http.ResponseWriter, r *http.Request) {
     var code int = http.StatusOK
     var err error = nil
     defer func(){
-        w.WriteHeader(code)
-        if err != nil {
-            fmt.Fprint(w, err)
+        if err == nil {
+            w.WriteHeader(code)
+        } else {
+            handlers.WriteError(w, code, "aliases", err.Error())
         }
     }()
 

--- a/handlers/docker/docker.go
+++ b/handlers/docker/docker.go
@@ -26,6 +26,7 @@ import (
     "github.com/lighthouse/lighthouse/session"
     "github.com/lighthouse/lighthouse/beacons"
     "github.com/lighthouse/lighthouse/handlers"
+    "github.com/lighthouse/lighthouse/beacons/aliases"
 )
 
 /*
@@ -112,13 +113,11 @@ func DockerHandler(w http.ResponseWriter, r *http.Request) {
     // Ready all HTTP form data for the handlers
     r.ParseForm()
 
-    info, ok := handlers.GetHandlerInfo(r)
+    info, ok := GetHandlerInfo(r)
 
     if !ok {
-        handlers.WriteError(w, handlers.HandlerError {
-            http.StatusBadRequest, 
-            "control", "could not get required data for handler",
-        })
+        handlers.WriteError(w, http.StatusBadRequest, 
+            "handlers", "could not get required data for handler")
         return
     }
 
@@ -137,6 +136,37 @@ func DockerHandler(w http.ResponseWriter, r *http.Request) {
     if err != nil {
         handlers.Rollback(w, *err, info, runCustomHandlers)
     }
+}
+
+/*
+    Extracts data from the request to create a HandlerInfo
+    which is used by the handlers.
+
+    RETURN: A HandlerInfo extracted from the request
+*/
+func GetHandlerInfo(r *http.Request) (handlers.HandlerInfo, bool) {
+    var info handlers.HandlerInfo
+
+    params, ok := handlers.GetEndpointParams(r, []string{"Host", "DockerEndpoint"})
+
+    if ok == false || len(params) < 2 {
+        return handlers.HandlerInfo{}, false
+    }
+
+    hostAlias := params["Host"]
+
+    value, err := aliases.GetAddressOf(hostAlias)
+    if err == nil {
+        info.Host = value
+    } else {
+        info.Host = hostAlias // Unknown alias, just use what was given
+    }
+
+    info.DockerEndpoint = params["DockerEndpoint"]
+    info.Body = handlers.GetRequestBody(r)
+    info.Request = r
+
+    return info, true
 }
 
 func Handle(r *mux.Router) {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -23,8 +23,6 @@ import (
     "io/ioutil"
 
     "github.com/gorilla/mux"
-
-    "github.com/lighthouse/lighthouse/beacons/aliases"
 )
 
 /*
@@ -68,7 +66,7 @@ type CustomHandlerMap map[*regexp.Regexp]CustomHandlerFunc
     Container of failure data created by the handlers
 */
 type HandlerError struct {
-    StatusCode  int
+    StatusCode  int     `json:"-"`
     Cause       string
     Message     string
 }
@@ -129,7 +127,7 @@ func Rollback(
     info HandlerInfo,
     runHandlers []CustomHandlerFunc,
 ) {
-    WriteError(w, err)
+    WriteError(w, err.StatusCode, err.Cause, err.Message)
     for _, handler := range runHandlers {
         handler(info, true)
     }
@@ -138,46 +136,13 @@ func Rollback(
 /*
     Writes error data and code to the HTTP response.
 */
-func WriteError(w http.ResponseWriter, err HandlerError) {
-    json, _ := json.Marshal(struct {
-        Error   string
-        Message string
-    }{err.Cause, err.Message})
-
+func WriteError(w http.ResponseWriter, code int, cause, message string) {
     w.Header().Set("Content-Type", "application/json")
-    w.WriteHeader(err.StatusCode)
+    w.WriteHeader(code)
+
+    err := HandlerError{Cause: cause, Message: message}
+    json, _ := json.Marshal(err)
     w.Write(json)
-}
-
-/*
-    Extracts data from the request to create a HandlerInfo
-    which is used by the handlers.
-
-    RETURN: A HandlerInfo extracted from the request
-*/
-func GetHandlerInfo(r *http.Request) (HandlerInfo, bool) {
-    var info HandlerInfo
-
-    params, ok := GetEndpointParams(r, []string{"Host", "DockerEndpoint"})
-
-    if ok == false || len(params) < 2 {
-        return HandlerInfo{}, false
-    }
-
-    hostAlias := params["Host"]
-
-    value, err := aliases.GetAddressOf(hostAlias)
-    if err == nil {
-        info.Host = value
-    } else {
-        info.Host = hostAlias // Unknown alias, just use what was given
-    }
-
-    info.DockerEndpoint = params["DockerEndpoint"]
-    info.Body = GetRequestBody(r)
-    info.Request = r
-
-    return info, true
 }
 
 /*

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -25,8 +25,6 @@ import (
 
     "github.com/gorilla/mux"
     "github.com/stretchr/testify/assert"
-
-    "github.com/lighthouse/lighthouse/beacons/aliases"
 )
 
 // Helper for GetRequestBody tests
@@ -96,35 +94,6 @@ func Test_GetRequestBody_NoPayload(t *testing.T) {
 }
 
 /*
-    Tests data extraction for requests into a HandlerInfo.
-    Purpose: To add ensure Handler get valid data.
-*/
-func Test_GetHandlerInfo(t *testing.T) {
-    aliases.SetupTestingTable()
-    defer aliases.TeardownTestingTable()
-
-    aliases.AddAlias("TestHost", "TestHost")
-
-    router := mux.NewRouter()
-    var info HandlerInfo
-
-    router.HandleFunc("/{Endpoint:.*}",
-        func(w http.ResponseWriter, r *http.Request) {
-            info, _ = GetHandlerInfo(r)
-    })
-
-    r, _ := http.NewRequest("GET", "/TestHost/Test%2FEndpoint", nil)
-    r.RequestURI = "/TestHost/Test%2FEndpoint"
-
-    router.ServeHTTP(httptest.NewRecorder(), r)
-
-    expected := HandlerInfo{"Test/Endpoint", "TestHost", nil, r}
-
-    assert.Equal(t, expected, info,
-        "GetHandlerInfo did not extract data correctly")
-}
-
-/*
     Validates that error messages are correctly generated for the user.
     Purpose: Ensuring handler errors reach the user correctly.
 */
@@ -133,7 +102,7 @@ func Test_WriteError(t *testing.T) {
 
     router.HandleFunc("/",
         func(w http.ResponseWriter, r *http.Request) {
-            WriteError(w, HandlerError{500, "TestCause", "TestMessage"})
+            WriteError(w, 500, "TestCause", "TestMessage")
     })
 
     w := httptest.NewRecorder()

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -21,6 +21,7 @@ import (
     "html/template"
 
     "github.com/lighthouse/lighthouse/auth"
+    "github.com/lighthouse/lighthouse/handlers"
     "github.com/lighthouse/lighthouse/beacons"
     "github.com/lighthouse/lighthouse/beacons/aliases"
     "github.com/lighthouse/lighthouse/users"
@@ -58,7 +59,7 @@ func ServeIndex(w http.ResponseWriter, r *http.Request) {
     } 
 
     if err != nil {
-        w.WriteHeader(404)
+        handlers.WriteError(w, 404, "lighthouse", err.Error())
     }
 }
 


### PR DESCRIPTION
**NOTE** this replaces https://github.com/lighthouse/lighthouse/pull/51
## What

Standardize all of Lighthouse's errors into a JSON scheme.  All codes >= 400 will also have JSON of the form:

``` json
{
    "Cause" : "<Package the error came from>",
    "Message" : "<Reason for the error>"
}
```
## Why

In reference to https://github.com/lighthouse/lighthouse-client/pull/34, the frontend handles all errors through one function.  This means errors need to always be of the same form.
## How

To ensure that errors are always the same, all error writes should now be processed through the `WriteError()` function in the `handlers` package:

``` go
func WriteError(w http.ResponseWriter, code int, cause, message string)
```
