### PR TITLE
HandlerInfo Bugfix

### DIFF
--- a/handlers/docker/docker.go
+++ b/handlers/docker/docker.go
@@ -149,6 +149,7 @@ func DockerHandler(w http.ResponseWriter, r *http.Request) {
 */
 func GetHandlerInfo(r *http.Request) (handlers.HandlerInfo, bool) {
     var info handlers.HandlerInfo
+    info.HandlerData = make(map[string]interface{})
 
     params, ok := handlers.GetEndpointParams(r, []string{"Host", "DockerEndpoint"})
 

--- a/handlers/docker/docker_test.go
+++ b/handlers/docker/docker_test.go
@@ -271,7 +271,8 @@ func Test_GetHandlerInfo(t *testing.T) {
 
     router.ServeHTTP(httptest.NewRecorder(), r)
 
-    expected := handlers.HandlerInfo{"Test/Endpoint", "AliasHost", nil, r, nil}
+    expected_map := make(map[string]interface{})
+    expected := handlers.HandlerInfo{"Test/Endpoint", "AliasHost", nil, r, expected_map}
 
     assert.Equal(t, expected, info,
         "GetHandlerInfo did not extract data correctly")


### PR DESCRIPTION
## What

Fixes the stacktrace @ngmiller stumbled upon (shown below)

```
2015/03/23 20:10:31 http: panic serving [::1]:50692: runtime error: assignment to entry in nil map
goroutine 53 [running]:
net/http.func·011()
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1100 +0xb7
runtime.panic(0x3c79a0, 0x651ad3)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/runtime/panic.c:248 +0x18d
github.com/lighthouse/lighthouse/handlers/containers.containerCreate(0xc208180cab, 0x1b, 0xc208179740, 0x19, 0xc20803ec68, 0xc208126000, 0x0, 0x1)
    /Users/Nick/.go/src/github.com/lighthouse/lighthouse/handlers/containers/handlers.go:70 +0x2bc
github.com/lighthouse/lighthouse/handlers/containers.ContainerCreateHandler(0xc208180cab, 0x1b, 0xc208179740, 0x19, 0xc20803ec68, 0xc208126000, 0x0, 0xc61800, 0x0)
    /Users/Nick/.go/src/github.com/lighthouse/lighthouse/handlers/containers/handlers.go:30 +0x6b
github.com/lighthouse/lighthouse/handlers.RunCustomHandlers(0xc208180cab, 0x1b, 0xc208179740, 0x19, 0xc20803ec68, 0xc208126000, 0x0, 0xc208165aa0, 0x0, 0x0, ...)
    /Users/Nick/.go/src/github.com/lighthouse/lighthouse/handlers/handlers.go:110 +0x131
github.com/lighthouse/lighthouse/handlers/docker.DockerHandler(0x725498, 0xc2080a2d20, 0xc208126000)
    /Users/Nick/.go/src/github.com/lighthouse/lighthouse/handlers/docker/docker.go:131 +0x17d
net/http.HandlerFunc.ServeHTTP(0x4eea98, 0x725498, 0xc2080a2d20, 0xc208126000)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1235 +0x40
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20801afa0, 0x725498, 0xc2080a2d20, 0xc208126000)
    /Users/Nick/.go/src/github.com/gorilla/mux/mux.go:98 +0x292
github.com/lighthouse/lighthouse/auth.func·001(0x725498, 0xc2080a2d20, 0xc208126000)
    /Users/Nick/.go/src/github.com/lighthouse/lighthouse/auth/auth.go:117 +0x3af
net/http.HandlerFunc.ServeHTTP(0xc20809cc20, 0x725498, 0xc2080a2d20, 0xc208126000)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1235 +0x40
github.com/lighthouse/lighthouse/logging.func·001(0x725498, 0xc2080a2d20, 0xc208126000)
    /Users/Nick/.go/src/github.com/lighthouse/lighthouse/logging/logging.go:34 +0x93
net/http.HandlerFunc.ServeHTTP(0xc2080fdde0, 0x725498, 0xc2080a2d20, 0xc208126000)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1235 +0x40
net/http.(*ServeMux).ServeHTTP(0xc208024690, 0x725498, 0xc2080a2d20, 0xc208126000)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1511 +0x1a3
net/http.serverHandler.ServeHTTP(0xc208005b60, 0x725498, 0xc2080a2d20, 0xc208126000)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1673 +0x19f
net/http.(*conn).serve(0xc208117c80)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1174 +0xa7e
created by net/http.(*Server).Serve
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1721 +0x313
2015/03/23 20:10:31  56.531779ms GET /api/v0.2/d/mylocalbeacon.boot2docker/containers/json?all=false
2015/03/23 20:10:31 http: panic serving [::1]:50697: runtime error: assignment to entry in nil map
goroutine 58 [running]:
net/http.func·011()
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1100 +0xb7
runtime.panic(0x3c79a0, 0x651ad3)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/runtime/panic.c:248 +0x18d
github.com/lighthouse/lighthouse/handlers/containers.containerCreate(0xc20818174b, 0x1b, 0xc208129960, 0x19, 0xc20803f608, 0xc208127c70, 0x0, 0x1)
    /Users/Nick/.go/src/github.com/lighthouse/lighthouse/handlers/containers/handlers.go:70 +0x2bc
github.com/lighthouse/lighthouse/handlers/containers.ContainerCreateHandler(0xc20818174b, 0x1b, 0xc208129960, 0x19, 0xc20803f608, 0xc208127c70, 0x0, 0xc61800, 0x0)
    /Users/Nick/.go/src/github.com/lighthouse/lighthouse/handlers/containers/handlers.go:30 +0x6b
github.com/lighthouse/lighthouse/handlers.RunCustomHandlers(0xc20818174b, 0x1b, 0xc208129960, 0x19, 0xc20803f608, 0xc208127c70, 0x0, 0xc2080f1ef0, 0x0, 0x0, ...)
    /Users/Nick/.go/src/github.com/lighthouse/lighthouse/handlers/handlers.go:110 +0x131
github.com/lighthouse/lighthouse/handlers/docker.DockerHandler(0x725498, 0xc2080a35e0, 0xc208127c70)
    /Users/Nick/.go/src/github.com/lighthouse/lighthouse/handlers/docker/docker.go:131 +0x17d
net/http.HandlerFunc.ServeHTTP(0x4eea98, 0x725498, 0xc2080a35e0, 0xc208127c70)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1235 +0x40
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20801afa0, 0x725498, 0xc2080a35e0, 0xc208127c70)
    /Users/Nick/.go/src/github.com/gorilla/mux/mux.go:98 +0x292
github.com/lighthouse/lighthouse/auth.func·001(0x725498, 0xc2080a35e0, 0xc208127c70)
    /Users/Nick/.go/src/github.com/lighthouse/lighthouse/auth/auth.go:117 +0x3af
net/http.HandlerFunc.ServeHTTP(0xc20809cc20, 0x725498, 0xc2080a35e0, 0xc208127c70)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1235 +0x40
github.com/lighthouse/lighthouse/logging.func·001(0x725498, 0xc2080a35e0, 0xc208127c70)
    /Users/Nick/.go/src/github.com/lighthouse/lighthouse/logging/logging.go:34 +0x93
net/http.HandlerFunc.ServeHTTP(0xc2080fdde0, 0x725498, 0xc2080a35e0, 0xc208127c70)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1235 +0x40
net/http.(*ServeMux).ServeHTTP(0xc208024690, 0x725498, 0xc2080a35e0, 0xc208127c70)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1511 +0x1a3
net/http.serverHandler.ServeHTTP(0xc208005b60, 0x725498, 0xc2080a35e0, 0xc208127c70)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1673 +0x19f
net/http.(*conn).serve(0xc208117a00)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1174 +0xa7e
created by net/http.(*Server).Serve
    /usr/local/Cellar/go/1.3/libexec/src/pkg/net/http/server.go:1721 +0x313
2015/03/23 20:10:31    763.898us GET /favicon.ico
2015/03/23 20:10:31 125.041039ms GET /api/v0.2/d/mylocalbeacon.boot2docker/images/json?all=false
```
