### PR TITLE
Database drivers

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -39,7 +39,7 @@ var SECRET_HASH_KEY string
 
 func Init(reload bool) {
     if users == nil { // defined in users.go
-        users = databases.NewSchemaTable(databases.DefaultConnection(), "users", schema)
+        users = databases.NewTable(databases.DefaultConnection(), "users", schema)
     }
 
     config := LoadAuthConfig()

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -48,7 +48,7 @@ func addUsers(list ...User) {
 	        "Password" : user.Password,
             "AuthLevel" : user.AuthLevel,
 	        "Permissions" : user.Permissions,
-	    }, "")
+	    })
 	}
 }
 
@@ -81,7 +81,7 @@ func Test_CreateUser(t *testing.T) {
     }
 
     var actual User
-    users.SelectRow(nil, nil, &actual)
+    users.SelectRow(nil, nil, nil, &actual)
 
 	assert.Equal(t, keyUser, actual)
 }
@@ -102,7 +102,7 @@ func Test_CreateUserWithAuthLevel(t *testing.T) {
     }
 
     var actual User
-    users.SelectRow(nil, nil, &actual)
+    users.SelectRow(nil, nil, nil, &actual)
 
 	assert.Equal(t, keyUser, actual)
 }
@@ -184,7 +184,7 @@ func Test_SetUserBeaconAuthLevel(t *testing.T) {
     SetUserBeaconAuthLevel(user, "NEW", 2)
 
     cols := []string{"Permissions"}
-    users.SelectRow(cols, nil, user)
+    users.SelectRow(cols, nil, nil, user)
 
     assert.Equal(t, keyPerms, user.Permissions["Beacons"])
 }
@@ -459,7 +459,7 @@ func Test_HandleUpdateUser_Valid(t *testing.T) {
     w := handleAndServe("/{Email}", handleUpdateUser, r)
 
     var user User
-    users.SelectRow(nil, nil, &user)
+    users.SelectRow(nil, nil, nil, &user)
 
     assert.Equal(t, http.StatusOK, w.Code)
     assert.Equal(t, keyUser, user)
@@ -491,7 +491,7 @@ func Test_HandleUpdateUser_NotAuthorized(t *testing.T) {
     w := handleAndServe("/{Email}", handleUpdateUser, r)
 
     var user User
-    users.SelectRow(nil, nil, &user)
+    users.SelectRow(nil, nil, nil, &user)
 
     assert.Equal(t, http.StatusForbidden, w.Code)
     assert.Equal(t, keyUser, user)
@@ -518,7 +518,7 @@ func Test_HandleUpdateUser_CantView(t *testing.T) {
     w := handleAndServe("/{Email}", handleUpdateUser, r)
 
     var user User
-    users.SelectRow(nil, nil, &user)
+    users.SelectRow(nil, nil, nil, &user)
 
     assert.Equal(t, http.StatusNotFound, w.Code)
 }
@@ -540,7 +540,7 @@ func Test_HandleUpdateUser_UnknownUser(t *testing.T) {
     w := handleAndServe("/{Email}", handleUpdateUser, r)
 
     var user User
-    users.SelectRow(nil, nil, &user)
+    users.SelectRow(nil, nil, nil, &user)
 
     assert.Equal(t, http.StatusNotFound, w.Code)
 }
@@ -562,7 +562,7 @@ func Test_HandleCreateUser_Valid(t *testing.T) {
 
     var user User
     where := databases.Filter{"Email" : "USER"}
-    users.SelectRow(nil, where, &user)
+    users.SelectRow(nil, where, nil, &user)
 
     assert.Equal(t, http.StatusOK, w.Code)
     assert.Equal(t, "USER", user.Email)

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -42,7 +42,7 @@ func teardown() {
 func addUsers(list ...User) {
 	for _, user := range list {
 
-		users.InsertSchema(map[string]interface{}{
+		users.Insert(map[string]interface{}{
 	        "Email" : user.Email,
 	        "Salt" : user.Salt,
 	        "Password" : user.Password,
@@ -81,7 +81,7 @@ func Test_CreateUser(t *testing.T) {
     }
 
     var actual User
-    users.SelectRowSchema(nil, nil, &actual)
+    users.SelectRow(nil, nil, &actual)
 
 	assert.Equal(t, keyUser, actual)
 }
@@ -102,7 +102,7 @@ func Test_CreateUserWithAuthLevel(t *testing.T) {
     }
 
     var actual User
-    users.SelectRowSchema(nil, nil, &actual)
+    users.SelectRow(nil, nil, &actual)
 
 	assert.Equal(t, keyUser, actual)
 }
@@ -184,7 +184,7 @@ func Test_SetUserBeaconAuthLevel(t *testing.T) {
     SetUserBeaconAuthLevel(user, "NEW", 2)
 
     cols := []string{"Permissions"}
-    users.SelectRowSchema(cols, nil, user)
+    users.SelectRow(cols, nil, user)
 
     assert.Equal(t, keyPerms, user.Permissions["Beacons"])
 }
@@ -459,7 +459,7 @@ func Test_HandleUpdateUser_Valid(t *testing.T) {
     w := handleAndServe("/{Email}", handleUpdateUser, r)
 
     var user User
-    users.SelectRowSchema(nil, nil, &user)
+    users.SelectRow(nil, nil, &user)
 
     assert.Equal(t, http.StatusOK, w.Code)
     assert.Equal(t, keyUser, user)
@@ -491,7 +491,7 @@ func Test_HandleUpdateUser_NotAuthorized(t *testing.T) {
     w := handleAndServe("/{Email}", handleUpdateUser, r)
 
     var user User
-    users.SelectRowSchema(nil, nil, &user)
+    users.SelectRow(nil, nil, &user)
 
     assert.Equal(t, http.StatusForbidden, w.Code)
     assert.Equal(t, keyUser, user)
@@ -518,7 +518,7 @@ func Test_HandleUpdateUser_CantView(t *testing.T) {
     w := handleAndServe("/{Email}", handleUpdateUser, r)
 
     var user User
-    users.SelectRowSchema(nil, nil, &user)
+    users.SelectRow(nil, nil, &user)
 
     assert.Equal(t, http.StatusNotFound, w.Code)
 }
@@ -540,7 +540,7 @@ func Test_HandleUpdateUser_UnknownUser(t *testing.T) {
     w := handleAndServe("/{Email}", handleUpdateUser, r)
 
     var user User
-    users.SelectRowSchema(nil, nil, &user)
+    users.SelectRow(nil, nil, &user)
 
     assert.Equal(t, http.StatusNotFound, w.Code)
 }
@@ -562,7 +562,7 @@ func Test_HandleCreateUser_Valid(t *testing.T) {
 
     var user User
     where := databases.Filter{"Email" : "USER"}
-    users.SelectRowSchema(nil, where, &user)
+    users.SelectRow(nil, where, &user)
 
     assert.Equal(t, http.StatusOK, w.Code)
     assert.Equal(t, "USER", user.Email)

--- a/auth/users.go
+++ b/auth/users.go
@@ -55,13 +55,6 @@ var schema = databases.Schema {
     "Permissions" : "json",
 }
 
-func getDBSingleton() databases.TableInterface {
-    if users == nil {
-        panic("Users database not initialized")
-    }
-    return users
-}
-
 func CreateUser(email, salt, password string) error {
     return createUserWithAuthLevel(email, salt, password, DefaultAuthLevel)
 }   
@@ -79,14 +72,14 @@ func addUser(user User) error {
         "Permissions" : user.Permissions,
     }
 
-    _, err := getDBSingleton().InsertSchema(entry, "")
+    _, err := users.Insert(entry, "")
     return err
 }
 
 func GetUser(email string) (*User, error) {
     user := &User{}
     where := databases.Filter{"Email" : email}
-    err := getDBSingleton().SelectRowSchema(nil, where, user)
+    err := users.SelectRow(nil, where, user)
 
     if err != nil {
         return nil, err
@@ -109,7 +102,7 @@ func SetUserBeaconAuthLevel(user *User, beacon string, level int) error {
     to := map[string]interface{}{"Permissions" : user.Permissions}
     where := map[string]interface{}{"Email" : user.Email}
 
-    return getDBSingleton().UpdateSchema(to, where)
+    return users.Update(to, where)
 }
 
 func writeResponse(w http.ResponseWriter, code int, err error) {
@@ -205,7 +198,7 @@ func handleUpdateUser(w http.ResponseWriter, r *http.Request) {
     }
 
     where := map[string]interface{}{"Email" : reqEmail}
-    err = getDBSingleton().UpdateSchema(values, where)
+    err = users.Update(values, where)
 
     if err != nil {
         writeResponse(w, http.StatusInternalServerError, err)
@@ -255,7 +248,7 @@ func handleCreateUser(w http.ResponseWriter, r *http.Request) {
 func getAllUsers(currentUser *User) ([]string, error) {
     opts := databases.SelectOptions{}
     cols := []string{"Email", "AuthLevel"}
-    userRows, err := getDBSingleton().SelectSchema(cols, nil, opts)
+    userRows, err := users.Select(cols, nil, opts)
 
     if err != nil {
         return nil, err

--- a/auth/users.go
+++ b/auth/users.go
@@ -72,14 +72,14 @@ func addUser(user User) error {
         "Permissions" : user.Permissions,
     }
 
-    _, err := users.Insert(entry, "")
+    err := users.Insert(entry)
     return err
 }
 
 func GetUser(email string) (*User, error) {
     user := &User{}
     where := databases.Filter{"Email" : email}
-    err := users.SelectRow(nil, where, user)
+    err := users.SelectRow(nil, where, nil, user)
 
     if err != nil {
         return nil, err
@@ -246,9 +246,8 @@ func handleCreateUser(w http.ResponseWriter, r *http.Request) {
 }
 
 func getAllUsers(currentUser *User) ([]string, error) {
-    opts := databases.SelectOptions{}
     cols := []string{"Email", "AuthLevel"}
-    userRows, err := users.Select(cols, nil, opts)
+    userRows, err := users.Select(cols, nil, nil)
 
     if err != nil {
         return nil, err

--- a/beacons/aliases/aliases.go
+++ b/beacons/aliases/aliases.go
@@ -56,7 +56,7 @@ func AddAlias(alias, address string) error {
         "Address" : address,
     }
 
-    _, err := aliases.Insert(entry, "")
+    err := aliases.Insert(entry)
 
     return err
 }
@@ -84,7 +84,7 @@ func GetAddressOf(alias string) (string, error) {
     
     var val Alias
 
-    err := aliases.SelectRow(cols, where, &val)
+    err := aliases.SelectRow(cols, where, nil, &val)
     
     if err != nil {
         return "", err
@@ -99,7 +99,7 @@ func GetAliasOf(address string) (string, error) {
     
     var val Alias
 
-    err := aliases.SelectRow(cols, where, &val)
+    err := aliases.SelectRow(cols, where, nil, &val)
     
     if err != nil {
         return "", err

--- a/beacons/aliases/aliases.go
+++ b/beacons/aliases/aliases.go
@@ -29,7 +29,7 @@ import (
 
 var aliases databases.TableInterface
 
-var schema = databases.Schema{
+var schema = databases.Schema {
     "Alias" : "text",
     "Address" : "text UNIQUE PRIMARY KEY",
 }
@@ -41,7 +41,7 @@ type Alias struct {
 
 func Init(reload bool) {
     if aliases == nil {
-        aliases = databases.NewSchemaTable(nil, "aliases", schema)
+        aliases = databases.NewTable(nil, "aliases", schema)
     }
 
     if reload {
@@ -56,7 +56,7 @@ func AddAlias(alias, address string) error {
         "Address" : address,
     }
 
-    _, err := aliases.InsertSchema(entry, "")
+    _, err := aliases.Insert(entry, "")
 
     return err
 }
@@ -65,7 +65,7 @@ func UpdateAlias(alias, address string) error {
     to := databases.Filter{"Alias": alias}
     where := databases.Filter{"Address" : address}
 
-    return aliases.UpdateSchema(to, where)
+    return aliases.Update(to, where)
 }
 
 func SetAlias(alias, address string) error {
@@ -84,7 +84,7 @@ func GetAddressOf(alias string) (string, error) {
     
     var val Alias
 
-    err := aliases.SelectRowSchema(cols, where, &val)
+    err := aliases.SelectRow(cols, where, &val)
     
     if err != nil {
         return "", err
@@ -99,7 +99,7 @@ func GetAliasOf(address string) (string, error) {
     
     var val Alias
 
-    err := aliases.SelectRowSchema(cols, where, &val)
+    err := aliases.SelectRow(cols, where, &val)
     
     if err != nil {
         return "", err

--- a/beacons/aliases/aliases_test.go
+++ b/beacons/aliases/aliases_test.go
@@ -49,7 +49,7 @@ func Test_AddAlias(t *testing.T) {
 		Address string
 	}
 
-	table.SelectRow([]string{"Address"}, nil, &real)
+	table.SelectRow([]string{"Address"}, nil, nil, &real)
 
 	assert.Equal(t, keyAddress, real.Address)
 }
@@ -63,7 +63,7 @@ func Test_UpdateAlias(t *testing.T) {
 		"Address" : "ADDRESS",
 	}
 
-	table.Insert(alias, "")
+	table.Insert(alias)
 
 	keyAlias := "ALIAS_PASS"
 
@@ -73,7 +73,7 @@ func Test_UpdateAlias(t *testing.T) {
 		Alias string
 	}
 
-	table.SelectRow([]string{"Alias"}, nil, &real)
+	table.SelectRow([]string{"Alias"}, nil, nil, &real)
 
 	assert.Equal(t, keyAlias, real.Alias)
 }
@@ -87,7 +87,7 @@ func Test_SetAlias(t *testing.T) {
 		"Address" : "ADDRESS_OVERWRITE",
 	}
 
-	table.Insert(alias, "")
+	table.Insert(alias)
 
 	overwriteAlias := "ALIAS_UPDATED"
 	SetAlias(overwriteAlias, "ADDRESS_OVERWRITE")
@@ -99,12 +99,12 @@ func Test_SetAlias(t *testing.T) {
 	where := make(databases.Filter)
 
 	where["Address"] = "ADDRESS_OVERWRITE"
-	table.SelectRow([]string{"Alias"}, where, &real)
+	table.SelectRow([]string{"Alias"}, where, nil, &real)
 
 	assert.Equal(t, overwriteAlias, real.Alias)
 
 	where["Address"] = "ADDRESS_ADDED"
-	table.SelectRow([]string{"Alias"}, where, &real)
+	table.SelectRow([]string{"Alias"}, where, nil, &real)
 
 	assert.Equal(t, addedAlias, real.Alias)
 }
@@ -118,7 +118,7 @@ func Test_GetAddressOf(t *testing.T) {
 		"Address" : "ADDRESS",
 	}
 
-	table.Insert(alias, "")
+	table.Insert(alias)
 
 	keyAddress := "ADDRESS"
 	var realAddress string
@@ -142,7 +142,7 @@ func Test_GetAliasOf(t *testing.T) {
 		"Address" : "ADDRESS",
 	}
 
-	table.Insert(alias, "")
+	table.Insert(alias)
 
 	keyAlias := "ALIAS"
 	var realAddress string
@@ -166,7 +166,7 @@ func Test_HandleUpdateAlias_Existing(t *testing.T) {
 		"Address" : "ADDRESS",
 	}
 
-	table.Insert(alias, "")
+	table.Insert(alias)
 
 	keyAlias := "ALIAS_PASS"
 	aliasJSON, _ := json.Marshal(keyAlias)
@@ -184,7 +184,7 @@ func Test_HandleUpdateAlias_Existing(t *testing.T) {
 		Alias string
 	}
 
-	table.SelectRow([]string{"Alias"}, nil, &real)
+	table.SelectRow([]string{"Alias"}, nil, nil, &real)
 	assert.Equal(t, keyAlias, real.Alias)
 }
 
@@ -208,7 +208,7 @@ func Test_HandleUpdateAlias_New(t *testing.T) {
 		Alias string
 	}
 
-	table.SelectRow([]string{"Alias"}, nil, &real)
+	table.SelectRow([]string{"Alias"}, nil, nil, &real)
 	assert.Equal(t, keyAlias, real.Alias)
 }
 

--- a/beacons/aliases/aliases_test.go
+++ b/beacons/aliases/aliases_test.go
@@ -49,7 +49,7 @@ func Test_AddAlias(t *testing.T) {
 		Address string
 	}
 
-	table.SelectRowSchema([]string{"Address"}, nil, &real)
+	table.SelectRow([]string{"Address"}, nil, &real)
 
 	assert.Equal(t, keyAddress, real.Address)
 }
@@ -63,7 +63,7 @@ func Test_UpdateAlias(t *testing.T) {
 		"Address" : "ADDRESS",
 	}
 
-	table.InsertSchema(alias, "")
+	table.Insert(alias, "")
 
 	keyAlias := "ALIAS_PASS"
 
@@ -73,7 +73,7 @@ func Test_UpdateAlias(t *testing.T) {
 		Alias string
 	}
 
-	table.SelectRowSchema([]string{"Alias"}, nil, &real)
+	table.SelectRow([]string{"Alias"}, nil, &real)
 
 	assert.Equal(t, keyAlias, real.Alias)
 }
@@ -87,7 +87,7 @@ func Test_SetAlias(t *testing.T) {
 		"Address" : "ADDRESS_OVERWRITE",
 	}
 
-	table.InsertSchema(alias, "")
+	table.Insert(alias, "")
 
 	overwriteAlias := "ALIAS_UPDATED"
 	SetAlias(overwriteAlias, "ADDRESS_OVERWRITE")
@@ -99,12 +99,12 @@ func Test_SetAlias(t *testing.T) {
 	where := make(databases.Filter)
 
 	where["Address"] = "ADDRESS_OVERWRITE"
-	table.SelectRowSchema([]string{"Alias"}, where, &real)
+	table.SelectRow([]string{"Alias"}, where, &real)
 
 	assert.Equal(t, overwriteAlias, real.Alias)
 
 	where["Address"] = "ADDRESS_ADDED"
-	table.SelectRowSchema([]string{"Alias"}, where, &real)
+	table.SelectRow([]string{"Alias"}, where, &real)
 
 	assert.Equal(t, addedAlias, real.Alias)
 }
@@ -118,7 +118,7 @@ func Test_GetAddressOf(t *testing.T) {
 		"Address" : "ADDRESS",
 	}
 
-	table.InsertSchema(alias, "")
+	table.Insert(alias, "")
 
 	keyAddress := "ADDRESS"
 	var realAddress string
@@ -142,7 +142,7 @@ func Test_GetAliasOf(t *testing.T) {
 		"Address" : "ADDRESS",
 	}
 
-	table.InsertSchema(alias, "")
+	table.Insert(alias, "")
 
 	keyAlias := "ALIAS"
 	var realAddress string
@@ -166,7 +166,7 @@ func Test_HandleUpdateAlias_Existing(t *testing.T) {
 		"Address" : "ADDRESS",
 	}
 
-	table.InsertSchema(alias, "")
+	table.Insert(alias, "")
 
 	keyAlias := "ALIAS_PASS"
 	aliasJSON, _ := json.Marshal(keyAlias)
@@ -184,7 +184,7 @@ func Test_HandleUpdateAlias_Existing(t *testing.T) {
 		Alias string
 	}
 
-	table.SelectRowSchema([]string{"Alias"}, nil, &real)
+	table.SelectRow([]string{"Alias"}, nil, &real)
 	assert.Equal(t, keyAlias, real.Alias)
 }
 
@@ -208,7 +208,7 @@ func Test_HandleUpdateAlias_New(t *testing.T) {
 		Alias string
 	}
 
-	table.SelectRowSchema([]string{"Alias"}, nil, &real)
+	table.SelectRow([]string{"Alias"}, nil, &real)
 	assert.Equal(t, keyAlias, real.Alias)
 }
 

--- a/beacons/beacons.go
+++ b/beacons/beacons.go
@@ -85,7 +85,7 @@ func GetBeaconAddress(instance string) (string, error) {
     where := databases.Filter{"InstanceAddress" : instance}
     columns := []string{"BeaconAddress"}
 
-    err := instances.SelectRow(columns, where, &beacon)
+    err := instances.SelectRow(columns, where, nil, &beacon)
 
     if err != nil {
         return "", err
@@ -103,7 +103,7 @@ func TryGetBeaconToken(beacon string, user *auth.User) (string, error) {
     where := databases.Filter{"Address" : beacon}
     columns := []string{"Token"}
 
-    err := beacons.SelectRow(columns, where, &data)
+    err := beacons.SelectRow(columns, where, nil, &data)
 
     if err != nil {
         return "", err

--- a/beacons/beacons.go
+++ b/beacons/beacons.go
@@ -66,11 +66,11 @@ type instanceData struct {
 
 func Init(reload bool) {
     if beacons == nil {
-        beacons = databases.NewSchemaTable(nil, "beacons", beaconSchema)
+        beacons = databases.NewTable(nil, "beacons", beaconSchema)
     }
 
     if instances == nil {
-        instances = databases.NewSchemaTable(nil, "instances", instanceSchema)
+        instances = databases.NewTable(nil, "instances", instanceSchema)
     }
 
     if reload {
@@ -85,7 +85,7 @@ func GetBeaconAddress(instance string) (string, error) {
     where := databases.Filter{"InstanceAddress" : instance}
     columns := []string{"BeaconAddress"}
 
-    err := instances.SelectRowSchema(columns, where, &beacon)
+    err := instances.SelectRow(columns, where, &beacon)
 
     if err != nil {
         return "", err
@@ -103,7 +103,7 @@ func TryGetBeaconToken(beacon string, user *auth.User) (string, error) {
     where := databases.Filter{"Address" : beacon}
     columns := []string{"Token"}
 
-    err := beacons.SelectRowSchema(columns, where, &data)
+    err := beacons.SelectRow(columns, where, &data)
 
     if err != nil {
         return "", err

--- a/beacons/beacons_test.go
+++ b/beacons/beacons_test.go
@@ -37,7 +37,7 @@ func Test_GetBeaconAddress_Found(t *testing.T) {
         "BeaconAddress" : "BEACON_ADDR", 
     }
 
-    instances.InsertSchema(testInstanceData, "")
+    instances.Insert(testInstanceData, "")
 
     res, err := GetBeaconAddress("INST_ADDR")
 
@@ -87,7 +87,7 @@ func Test_GetBeaconToken_NotPermitted(t *testing.T) {
         "Token" : "TOKEN",
     }
 
-    beacons.InsertSchema(testBeaconData, "")
+    beacons.Insert(testBeaconData, "")
 
     auth.CreateUser("EMAIL", "", "")
     user, _ := auth.GetUser("EMAIL")
@@ -109,7 +109,7 @@ func Test_GetBeaconToken_Valid(t *testing.T) {
         "Token" : "TOKEN", 
     }
 
-    beacons.InsertSchema(testBeaconData, "")
+    beacons.Insert(testBeaconData, "")
 
     auth.CreateUser("EMAIL", "", "")
     user, _ := auth.GetUser("EMAIL")

--- a/beacons/beacons_test.go
+++ b/beacons/beacons_test.go
@@ -37,7 +37,7 @@ func Test_GetBeaconAddress_Found(t *testing.T) {
         "BeaconAddress" : "BEACON_ADDR", 
     }
 
-    instances.Insert(testInstanceData, "")
+    instances.Insert(testInstanceData)
 
     res, err := GetBeaconAddress("INST_ADDR")
 
@@ -87,7 +87,7 @@ func Test_GetBeaconToken_NotPermitted(t *testing.T) {
         "Token" : "TOKEN",
     }
 
-    beacons.Insert(testBeaconData, "")
+    beacons.Insert(testBeaconData)
 
     auth.CreateUser("EMAIL", "", "")
     user, _ := auth.GetUser("EMAIL")
@@ -109,7 +109,7 @@ func Test_GetBeaconToken_Valid(t *testing.T) {
         "Token" : "TOKEN", 
     }
 
-    beacons.Insert(testBeaconData, "")
+    beacons.Insert(testBeaconData)
 
     auth.CreateUser("EMAIL", "", "")
     user, _ := auth.GetUser("EMAIL")

--- a/beacons/handlers.go
+++ b/beacons/handlers.go
@@ -93,7 +93,7 @@ func handleUpdateBeaconToken(w http.ResponseWriter, r *http.Request) {
 
     to := map[string]interface{}{"Token" : token}
     where := map[string]interface{}{"Address" : beacon}
-    err = beacons.UpdateSchema(to, where)
+    err = beacons.Update(to, where)
 
     return
 }

--- a/beacons/handlers_test.go
+++ b/beacons/handlers_test.go
@@ -83,7 +83,7 @@ func Test_HandleUpdateBeaconToken(t *testing.T) {
 	setup()
 	defer teardown()
 
-	beacons.InsertSchema(map[string]interface{}{
+	beacons.Insert(map[string]interface{}{
 		"Address" : "ADDR", "Token" : "TOKEN",
 	}, "")
 
@@ -93,7 +93,7 @@ func Test_HandleUpdateBeaconToken(t *testing.T) {
     assert.Equal(t, 200, w.Code)
 
     var data beaconData
-    beacons.SelectRowSchema(nil, nil, &data)
+    beacons.SelectRow(nil, nil, &data)
     assert.Equal(t, "TOKEN_PASS", data.Token)
 }
 
@@ -143,7 +143,7 @@ func Test_HandleBeaconCreate(t *testing.T) {
     assert.Equal(t, "ALIAS_PASS", alias)
 
     var beacon beaconData
-    beacons.SelectRowSchema(nil, nil, &beacon)
+    beacons.SelectRow(nil, nil, &beacon)
     assert.Equal(t, "localhost:8080", beacon.Address)
 	assert.Equal(t, "TOKEN_PASS", beacon.Token)
 }
@@ -176,7 +176,7 @@ func Test_HandleBeaconCreate_Invalid(t *testing.T) {
 
 	// Duplicate beacon
 	body = map[string]interface{} {"Address" : "localhost:8080", "Token" : ""}
-	beacons.InsertSchema(body, "")
+	beacons.Insert(body, "")
 	body["Alias"] = "ALIAS"
 
     defer setupServer(nil).Close()

--- a/beacons/handlers_test.go
+++ b/beacons/handlers_test.go
@@ -85,7 +85,7 @@ func Test_HandleUpdateBeaconToken(t *testing.T) {
 
 	beacons.Insert(map[string]interface{}{
 		"Address" : "ADDR", "Token" : "TOKEN",
-	}, "")
+	})
 
 	setupBeaconPermissions("ADDR", 2)
 	w := runHandlerTest("PUT", "/ADDR", "TOKEN_PASS", "/{Endpoint}", handleUpdateBeaconToken)
@@ -93,7 +93,7 @@ func Test_HandleUpdateBeaconToken(t *testing.T) {
     assert.Equal(t, 200, w.Code)
 
     var data beaconData
-    beacons.SelectRow(nil, nil, &data)
+    beacons.SelectRow(nil, nil, nil, &data)
     assert.Equal(t, "TOKEN_PASS", data.Token)
 }
 
@@ -143,7 +143,7 @@ func Test_HandleBeaconCreate(t *testing.T) {
     assert.Equal(t, "ALIAS_PASS", alias)
 
     var beacon beaconData
-    beacons.SelectRow(nil, nil, &beacon)
+    beacons.SelectRow(nil, nil, nil, &beacon)
     assert.Equal(t, "localhost:8080", beacon.Address)
 	assert.Equal(t, "TOKEN_PASS", beacon.Token)
 }
@@ -176,7 +176,7 @@ func Test_HandleBeaconCreate_Invalid(t *testing.T) {
 
 	// Duplicate beacon
 	body = map[string]interface{} {"Address" : "localhost:8080", "Token" : ""}
-	beacons.Insert(body, "")
+	beacons.Insert(body)
 	body["Alias"] = "ALIAS"
 
     defer setupServer(nil).Close()

--- a/beacons/helpers.go
+++ b/beacons/helpers.go
@@ -30,7 +30,7 @@ func beaconExists(beacon string) bool {
     columns := []string{"Address"}
     where := databases.Filter{"Address" : beacon}
 
-    err := beacons.SelectRowSchema(columns, where, &test)
+    err := beacons.SelectRow(columns, where, &test)
     return err != databases.NoRowsError
 }
 
@@ -39,7 +39,7 @@ func instanceExists(instance string) bool {
     columns := []string{"InstanceAddress"}
     where := databases.Filter{"InstanceAddress" : instance}
 
-    err := instances.SelectRowSchema(columns, where, &test)
+    err := instances.SelectRow(columns, where, &test)
     return err != databases.NoRowsError
 }
 
@@ -49,7 +49,7 @@ func addBeacon(beacon beaconData) error {
         "Token" : beacon.Token,
     }
 
-    _, err := beacons.InsertSchema(entry, "")
+    _, err := beacons.Insert(entry, "")
     return err
 }
 
@@ -60,7 +60,7 @@ func addInstance(instance instanceData) error {
         "CanAccessDocker" : instance.CanAccessDocker,
         "BeaconAddress" : instance.BeaconAddress,
     }
-    _, err := instances.InsertSchema(entry, "")
+    _, err := instances.Insert(entry, "")
     return err
 }
 
@@ -73,21 +73,21 @@ func updateInstance(instance instanceData) error {
 
     where := map[string]interface{} {"InstanceAddress": instance.InstanceAddress}
 
-    return instances.UpdateSchema(to, where)
+    return instances.Update(to, where)
 }
 
 func updateBeaconField(field string, val interface{}, beacon string) error {
     to := databases.Filter{field : val}
     where := databases.Filter{"Address": beacon}
 
-    return beacons.UpdateSchema(to, where)
+    return beacons.Update(to, where)
 }
 
 func getBeaconData(beacon string) (beaconData, error) {
     var data beaconData
     where := databases.Filter{"Address" : beacon}
 
-    err := beacons.SelectRowSchema(nil, where, &data)
+    err := beacons.SelectRow(nil, where, &data)
 
     if err != nil {
         return beaconData{}, err
@@ -99,7 +99,7 @@ func getBeaconData(beacon string) (beaconData, error) {
 func getBeaconsList(user *auth.User) ([]aliases.Alias, error) {
     opts := databases.SelectOptions{}
     cols := []string{"Address"}
-    scanner, err := beacons.SelectSchema(cols, nil, opts)
+    scanner, err := beacons.Select(cols, nil, opts)
 
     if err != nil {
         return nil, err
@@ -145,7 +145,7 @@ func getInstancesList(beacon string, user *auth.User, refresh bool) ([]map[strin
     opts := databases.SelectOptions{Distinct : true}
     where := databases.Filter{"BeaconAddress": beacon}
 
-    scanner, err := instances.SelectSchema(nil, where, opts)
+    scanner, err := instances.Select(nil, where, opts)
     if err != nil {
         return nil, err
     }

--- a/beacons/helpers.go
+++ b/beacons/helpers.go
@@ -30,7 +30,7 @@ func beaconExists(beacon string) bool {
     columns := []string{"Address"}
     where := databases.Filter{"Address" : beacon}
 
-    err := beacons.SelectRow(columns, where, &test)
+    err := beacons.SelectRow(columns, where, nil, &test)
     return err != databases.NoRowsError
 }
 
@@ -39,7 +39,7 @@ func instanceExists(instance string) bool {
     columns := []string{"InstanceAddress"}
     where := databases.Filter{"InstanceAddress" : instance}
 
-    err := instances.SelectRow(columns, where, &test)
+    err := instances.SelectRow(columns, where, nil, &test)
     return err != databases.NoRowsError
 }
 
@@ -49,7 +49,7 @@ func addBeacon(beacon beaconData) error {
         "Token" : beacon.Token,
     }
 
-    _, err := beacons.Insert(entry, "")
+    err := beacons.Insert(entry)
     return err
 }
 
@@ -60,7 +60,8 @@ func addInstance(instance instanceData) error {
         "CanAccessDocker" : instance.CanAccessDocker,
         "BeaconAddress" : instance.BeaconAddress,
     }
-    _, err := instances.Insert(entry, "")
+    
+    err := instances.Insert(entry)
     return err
 }
 
@@ -87,7 +88,7 @@ func getBeaconData(beacon string) (beaconData, error) {
     var data beaconData
     where := databases.Filter{"Address" : beacon}
 
-    err := beacons.SelectRow(nil, where, &data)
+    err := beacons.SelectRow(nil, where, nil, &data)
 
     if err != nil {
         return beaconData{}, err
@@ -97,9 +98,8 @@ func getBeaconData(beacon string) (beaconData, error) {
 }
 
 func getBeaconsList(user *auth.User) ([]aliases.Alias, error) {
-    opts := databases.SelectOptions{}
     cols := []string{"Address"}
-    scanner, err := beacons.Select(cols, nil, opts)
+    scanner, err := beacons.Select(cols, nil, nil)
 
     if err != nil {
         return nil, err
@@ -145,7 +145,7 @@ func getInstancesList(beacon string, user *auth.User, refresh bool) ([]map[strin
     opts := databases.SelectOptions{Distinct : true}
     where := databases.Filter{"BeaconAddress": beacon}
 
-    scanner, err := instances.Select(nil, where, opts)
+    scanner, err := instances.Select(nil, where, &opts)
     if err != nil {
         return nil, err
     }

--- a/beacons/helpers_test.go
+++ b/beacons/helpers_test.go
@@ -39,7 +39,7 @@ func Test_BeaconExists_True(t *testing.T) {
         "Token" : "TOKEN", 
     }
 
-    beacons.Insert(testData, "")
+    beacons.Insert(testData)
 
     assert.True(t, beaconExists("BEACON_ADDR"))
 }
@@ -62,7 +62,7 @@ func Test_InstanceExists_True(t *testing.T) {
         "CanAccessDocker" : true,
     }
 
-    instances.Insert(testData, "")
+    instances.Insert(testData)
 
     assert.True(t, instanceExists("INST_ADDR"))
 }
@@ -85,7 +85,7 @@ func Test_AddBeaconData_New(t *testing.T) {
     addBeacon(testBeaconData)
 
     var values beaconData
-    beacons.SelectRow(nil, nil, &values)
+    beacons.SelectRow(nil, nil, nil, &values)
 
     assert.Equal(t, testBeaconData, values)
 }
@@ -117,7 +117,7 @@ func Test_AddInstanceData_New(t *testing.T) {
     addInstance(testData)
 
     var values instanceData
-    instances.SelectRow(nil, nil, &values)
+    instances.SelectRow(nil, nil, nil, &values)
 
     assert.Equal(t, testData, values)
 }
@@ -147,16 +147,16 @@ func Test_UpdateBeaconData(t *testing.T) {
         "Token" : "TOKEN_FAIL", 
     }
 
-    beacons.Insert(testBeaconData, "")
+    beacons.Insert(testBeaconData)
 
     var result beaconData
     
     updateBeaconField("Token", "TOKEN_PASS", "ADDR_FAIL")
-    beacons.SelectRow(nil, nil, &result)
+    beacons.SelectRow(nil, nil, nil, &result)
     assert.Equal(t, "TOKEN_PASS", result.Token)
 
     updateBeaconField("Address", "ADDR_PASS", "ADDR_FAIL")
-    beacons.SelectRow(nil, nil, &result)
+    beacons.SelectRow(nil, nil, nil, &result)
     assert.Equal(t, "ADDR_PASS", result.Address)
 }
 
@@ -171,7 +171,7 @@ func Test_UpdateInstanceData(t *testing.T) {
         "BeaconAddress" : "BEACON_ADDR", 
     }
 
-    instances.Insert(testInstanceData, "")
+    instances.Insert(testInstanceData)
 
     keyInstance := instanceData {
         "INST_ADDR", "NAME_PASS", true, "BEACON_PASS",
@@ -180,7 +180,7 @@ func Test_UpdateInstanceData(t *testing.T) {
     var result instanceData
     
     updateInstance(keyInstance)
-    instances.SelectRow(nil, nil, &result)
+    instances.SelectRow(nil, nil, nil, &result)
     assert.Equal(t, keyInstance, result)
 }
 
@@ -193,7 +193,7 @@ func Test_GetBeaconData_Found(t *testing.T) {
         "Token" : "TOKEN", 
     }
 
-    beacons.Insert(testBeaconData, "")
+    beacons.Insert(testBeaconData)
 
     res, err := getBeaconData("BEACON_ADDR")
 
@@ -242,7 +242,7 @@ func Test_ListBeacons_ValidUser(t *testing.T) {
         auth.SetUserBeaconAuthLevel(user, addr, auth.OwnerAuthLevel)
 
         keyList = append(keyList, aliases.Alias{"", newBeacon["Address"].(string)})
-        beacons.Insert(newBeacon, "")
+        beacons.Insert(newBeacon)
     }
 
     beaconList, err := getBeaconsList(user)
@@ -269,8 +269,8 @@ func Test_ListBeacons_BadUser(t *testing.T) {
     user, _ := auth.GetUser("EMAIL")
     auth.SetUserBeaconAuthLevel(user, "BEACON_ADDR 1", auth.OwnerAuthLevel)
 
-    beacons.Insert(goodBeacon, "")
-    beacons.Insert(badBeacon, "")
+    beacons.Insert(goodBeacon)
+    beacons.Insert(badBeacon)
 
     beaconList, err := getBeaconsList(user)
 
@@ -289,7 +289,7 @@ func Test_ListInstances_ValidUser(t *testing.T) {
 
     beacons.Insert(map[string]interface{}{
         "Address" : "BEACON_ADDR", "Token" : "TOKEN",
-    }, "")
+    })
 
     keyList := make([]map[string]interface{}, 0)
 
@@ -307,7 +307,7 @@ func Test_ListInstances_ValidUser(t *testing.T) {
             "BeaconAddress" : "BEACON_ADDR", 
         }
 
-        instances.Insert(newInstance, "")
+        instances.Insert(newInstance)
 
         newInstance["Alias"] = ""
         keyList = append(keyList, newInstance)
@@ -325,7 +325,7 @@ func Test_ListInstances_BadUser(t *testing.T) {
 
     beacons.Insert(map[string]interface{}{
         "Address" : "BEACON_ADDR", "Token" : "TOKEN",
-    }, "")
+    })
 
     auth.CreateUser("EMAIL", "", "")
     user, _ := auth.GetUser("EMAIL")
@@ -337,7 +337,7 @@ func Test_ListInstances_BadUser(t *testing.T) {
         "BeaconAddress" : "BEACON_ADDR", 
     }
 
-    instances.Insert(instance, "")
+    instances.Insert(instance)
 
     key := []map[string]interface{}{}
 
@@ -361,7 +361,7 @@ func Test_ListInstances_BadBeacon(t *testing.T) {
         "BeaconAddress" : "BEACON_ADDR", 
     }
 
-    instances.Insert(instance, "")
+    instances.Insert(instance)
 
     key := []map[string]interface{}{}
 
@@ -403,7 +403,7 @@ func Test_RefreshVMListOf_Valid(t *testing.T) {
     }
 
     var inst instanceData
-    instances.SelectRow(nil, nil, &inst)
+    instances.SelectRow(nil, nil, nil, &inst)
 
     assert.Equal(t, key, inst)
 }
@@ -471,7 +471,7 @@ func Test_RefreshVMListOf_Update(t *testing.T) {
         "Name" : "NAME_FAIL",
         "CanAccessDocker" : false,
         "BeaconAddress" : "ADDR_FAIL",
-    }, "")
+    })
 
     f := func(w http.ResponseWriter, r *http.Request) {
         val, _ := json.Marshal([]structs.VM{vm})
@@ -494,7 +494,7 @@ func Test_RefreshVMListOf_Update(t *testing.T) {
     }
 
     var inst instanceData
-    instances.SelectRow(nil, nil, &inst)
+    instances.SelectRow(nil, nil, nil, &inst)
 
     assert.Equal(t, key, inst)
 }

--- a/beacons/helpers_test.go
+++ b/beacons/helpers_test.go
@@ -39,7 +39,7 @@ func Test_BeaconExists_True(t *testing.T) {
         "Token" : "TOKEN", 
     }
 
-    beacons.InsertSchema(testData, "")
+    beacons.Insert(testData, "")
 
     assert.True(t, beaconExists("BEACON_ADDR"))
 }
@@ -62,7 +62,7 @@ func Test_InstanceExists_True(t *testing.T) {
         "CanAccessDocker" : true,
     }
 
-    instances.InsertSchema(testData, "")
+    instances.Insert(testData, "")
 
     assert.True(t, instanceExists("INST_ADDR"))
 }
@@ -85,7 +85,7 @@ func Test_AddBeaconData_New(t *testing.T) {
     addBeacon(testBeaconData)
 
     var values beaconData
-    beacons.SelectRowSchema(nil, nil, &values)
+    beacons.SelectRow(nil, nil, &values)
 
     assert.Equal(t, testBeaconData, values)
 }
@@ -117,7 +117,7 @@ func Test_AddInstanceData_New(t *testing.T) {
     addInstance(testData)
 
     var values instanceData
-    instances.SelectRowSchema(nil, nil, &values)
+    instances.SelectRow(nil, nil, &values)
 
     assert.Equal(t, testData, values)
 }
@@ -147,16 +147,16 @@ func Test_UpdateBeaconData(t *testing.T) {
         "Token" : "TOKEN_FAIL", 
     }
 
-    beacons.InsertSchema(testBeaconData, "")
+    beacons.Insert(testBeaconData, "")
 
     var result beaconData
     
     updateBeaconField("Token", "TOKEN_PASS", "ADDR_FAIL")
-    beacons.SelectRowSchema(nil, nil, &result)
+    beacons.SelectRow(nil, nil, &result)
     assert.Equal(t, "TOKEN_PASS", result.Token)
 
     updateBeaconField("Address", "ADDR_PASS", "ADDR_FAIL")
-    beacons.SelectRowSchema(nil, nil, &result)
+    beacons.SelectRow(nil, nil, &result)
     assert.Equal(t, "ADDR_PASS", result.Address)
 }
 
@@ -171,7 +171,7 @@ func Test_UpdateInstanceData(t *testing.T) {
         "BeaconAddress" : "BEACON_ADDR", 
     }
 
-    instances.InsertSchema(testInstanceData, "")
+    instances.Insert(testInstanceData, "")
 
     keyInstance := instanceData {
         "INST_ADDR", "NAME_PASS", true, "BEACON_PASS",
@@ -180,7 +180,7 @@ func Test_UpdateInstanceData(t *testing.T) {
     var result instanceData
     
     updateInstance(keyInstance)
-    instances.SelectRowSchema(nil, nil, &result)
+    instances.SelectRow(nil, nil, &result)
     assert.Equal(t, keyInstance, result)
 }
 
@@ -193,7 +193,7 @@ func Test_GetBeaconData_Found(t *testing.T) {
         "Token" : "TOKEN", 
     }
 
-    beacons.InsertSchema(testBeaconData, "")
+    beacons.Insert(testBeaconData, "")
 
     res, err := getBeaconData("BEACON_ADDR")
 
@@ -242,7 +242,7 @@ func Test_ListBeacons_ValidUser(t *testing.T) {
         auth.SetUserBeaconAuthLevel(user, addr, auth.OwnerAuthLevel)
 
         keyList = append(keyList, aliases.Alias{"", newBeacon["Address"].(string)})
-        beacons.InsertSchema(newBeacon, "")
+        beacons.Insert(newBeacon, "")
     }
 
     beaconList, err := getBeaconsList(user)
@@ -269,8 +269,8 @@ func Test_ListBeacons_BadUser(t *testing.T) {
     user, _ := auth.GetUser("EMAIL")
     auth.SetUserBeaconAuthLevel(user, "BEACON_ADDR 1", auth.OwnerAuthLevel)
 
-    beacons.InsertSchema(goodBeacon, "")
-    beacons.InsertSchema(badBeacon, "")
+    beacons.Insert(goodBeacon, "")
+    beacons.Insert(badBeacon, "")
 
     beaconList, err := getBeaconsList(user)
 
@@ -287,7 +287,7 @@ func Test_ListInstances_ValidUser(t *testing.T) {
     user, _ := auth.GetUser("EMAIL")
     auth.SetUserBeaconAuthLevel(user, "BEACON_ADDR", auth.OwnerAuthLevel)
 
-    beacons.InsertSchema(map[string]interface{}{
+    beacons.Insert(map[string]interface{}{
         "Address" : "BEACON_ADDR", "Token" : "TOKEN",
     }, "")
 
@@ -307,7 +307,7 @@ func Test_ListInstances_ValidUser(t *testing.T) {
             "BeaconAddress" : "BEACON_ADDR", 
         }
 
-        instances.InsertSchema(newInstance, "")
+        instances.Insert(newInstance, "")
 
         newInstance["Alias"] = ""
         keyList = append(keyList, newInstance)
@@ -323,7 +323,7 @@ func Test_ListInstances_BadUser(t *testing.T) {
     setup()
     defer teardown()
 
-    beacons.InsertSchema(map[string]interface{}{
+    beacons.Insert(map[string]interface{}{
         "Address" : "BEACON_ADDR", "Token" : "TOKEN",
     }, "")
 
@@ -337,7 +337,7 @@ func Test_ListInstances_BadUser(t *testing.T) {
         "BeaconAddress" : "BEACON_ADDR", 
     }
 
-    instances.InsertSchema(instance, "")
+    instances.Insert(instance, "")
 
     key := []map[string]interface{}{}
 
@@ -361,7 +361,7 @@ func Test_ListInstances_BadBeacon(t *testing.T) {
         "BeaconAddress" : "BEACON_ADDR", 
     }
 
-    instances.InsertSchema(instance, "")
+    instances.Insert(instance, "")
 
     key := []map[string]interface{}{}
 
@@ -403,7 +403,7 @@ func Test_RefreshVMListOf_Valid(t *testing.T) {
     }
 
     var inst instanceData
-    instances.SelectRowSchema(nil, nil, &inst)
+    instances.SelectRow(nil, nil, &inst)
 
     assert.Equal(t, key, inst)
 }
@@ -466,7 +466,7 @@ func Test_RefreshVMListOf_Update(t *testing.T) {
         CanAccessDocker : true,
     }
 
-    instances.InsertSchema(map[string]interface{}{
+    instances.Insert(map[string]interface{}{
         "InstanceAddress" : fmt.Sprintf("%s:%s/%s", vm.Address, vm.Port, vm.Version),
         "Name" : "NAME_FAIL",
         "CanAccessDocker" : false,
@@ -494,7 +494,7 @@ func Test_RefreshVMListOf_Update(t *testing.T) {
     }
 
     var inst instanceData
-    instances.SelectRowSchema(nil, nil, &inst)
+    instances.SelectRow(nil, nil, &inst)
 
     assert.Equal(t, key, inst)
 }

--- a/databases/databases_test.go
+++ b/databases/databases_test.go
@@ -53,6 +53,14 @@ func (t *testCompiler) ConvertOutput(o interface{}, c string) (interface{}) {
     return o 
 }
 
+func (t *testCompiler) CompileCreate(tab string) (string) {
+    return "CREATE"
+}
+
+func (t *testCompiler) CompileDrop(tab string) (string) {
+    return "DROP"
+}
+
 func (t *testCompiler) CompileInsert(tab string, val map[string]interface{}) (string, []interface{}) {
     return "INSERT", []interface{}{}
 }
@@ -137,17 +145,11 @@ func Test_NewLockingTable_Panic(t *testing.T) {
 
 func Test_Reload(t *testing.T) {
     db := testDB()
-    schema := Schema {
-        "Name" : "text UNIQUE PRIMARY KEY",
-        "Age" : "integer",
-        "Phone" : "text",
-        "Info" : "json",
-    }
 
-    sqlmock.ExpectExec(`DROP TABLE test_table;`)
-    sqlmock.ExpectExec(`CREATE TABLE test_table .+`)
+    sqlmock.ExpectExec(`DROP`)
+    sqlmock.ExpectExec(`CREATE`)
 
-    NewTable(db, "test_table", schema).Reload()
+    NewTable(db, "test_table", testSchema).Reload()
 
     if err := db.Close(); err != nil {
         t.Errorf(err.Error())

--- a/databases/interfaces.go
+++ b/databases/interfaces.go
@@ -29,14 +29,17 @@ type DBInterface interface {
     Query(string, ...interface{}) (*sql.Rows, error)
     QueryRow(string, ...interface{}) *sql.Row
     SetMaxIdleConns(int)
+
+    Compiler(Schema) Compiler
 }
 
 type TableInterface interface {
-    Insert(map[string]interface{}, string)(interface{}, error)
+    Insert(map[string]interface{})(error)
+    InsertReturn(map[string]interface{}, []string, *SelectOptions, interface{})(error)
     Delete(Filter) (error)
     Update(map[string]interface{}, Filter)(error)
-    SelectRow([]string, Filter, interface{})(error)
-    Select([]string, Filter, SelectOptions)(ScannerInterface, error)
+    SelectRow([]string, Filter, *SelectOptions, interface{})(error)
+    Select([]string, Filter, *SelectOptions)(ScannerInterface, error)
     Reload()
 }
 
@@ -46,4 +49,14 @@ type ScannerInterface interface {
     Err()(error)
     Next()(bool)
     Scan(dest interface{})(error)
+}
+
+type Compiler interface {
+    ConvertInput(interface{}, string) interface{}
+    ConvertOutput(interface{}, string) interface{}
+
+    CompileInsert(string, map[string]interface{}) (string, []interface{})
+    CompileDelete(string, Filter) (string, []interface{})
+    CompileUpdate(string, map[string]interface{}, Filter) (string, []interface{})
+    CompileSelect(string, []string, Filter, *SelectOptions) (string, []interface{})
 }

--- a/databases/interfaces.go
+++ b/databases/interfaces.go
@@ -32,14 +32,11 @@ type DBInterface interface {
 }
 
 type TableInterface interface {
-    Insert(string, interface{})(error)
-    Update(string, interface{})(error)
-    SelectRow(string, interface{})(error)
-    InsertSchema(map[string]interface{}, string)(interface{}, error)
-    DeleteRowsSchema(Filter) (error)
-    UpdateSchema(map[string]interface{}, map[string]interface{})(error)
-    SelectRowSchema([]string, Filter, interface{})(error)
-    SelectSchema([]string, Filter, SelectOptions)(ScannerInterface, error)
+    Insert(map[string]interface{}, string)(interface{}, error)
+    Delete(Filter) (error)
+    Update(map[string]interface{}, Filter)(error)
+    SelectRow([]string, Filter, interface{})(error)
+    Select([]string, Filter, SelectOptions)(ScannerInterface, error)
     Reload()
 }
 

--- a/databases/interfaces.go
+++ b/databases/interfaces.go
@@ -55,6 +55,8 @@ type Compiler interface {
     ConvertInput(interface{}, string) interface{}
     ConvertOutput(interface{}, string) interface{}
 
+    CompileCreate(string) (string)
+    CompileDrop(string) (string)
     CompileInsert(string, map[string]interface{}) (string, []interface{})
     CompileDelete(string, Filter) (string, []interface{})
     CompileUpdate(string, map[string]interface{}, Filter) (string, []interface{})

--- a/databases/mocktable_testing_utils.go
+++ b/databases/mocktable_testing_utils.go
@@ -29,55 +29,37 @@ type MockTable struct {
     Schema map[string]int
     lastUpdateRow int64
 
-    MockInsert           func(string, interface{})(error)
-    MockUpdate           func(string, interface{})(error)
-    MockSelectRow        func(string, interface{})(error)
-    MockInsertSchema     func(map[string]interface{}, string)(interface{}, error)
-    MockDeleteRowsSchema func(Filter)(error)
-    MockUpdateSchema     func(map[string]interface{}, map[string]interface{})(error)
-    MockSelectRowSchema  func([]string, Filter, interface{})(error)
-    MockSelectSchema     func([]string, Filter, SelectOptions)(ScannerInterface, error)
+    MockInsert     func(map[string]interface{}, string)(interface{}, error)
+    MockDelete     func(Filter)(error)
+    MockUpdate     func(map[string]interface{}, Filter)(error)
+    MockSelectRow  func([]string, Filter, interface{})(error)
+    MockSelect     func([]string, Filter, SelectOptions)(ScannerInterface, error)
 
     MockReload           func()
 }
 
-func (t *MockTable) Insert(s string, i interface{})(e error) {
-    if t.MockInsert != nil { return t.MockInsert(s, i) }
+func (t *MockTable) Insert(v map[string]interface{}, returnCol string)(i interface{}, e error) {
+    if t.MockInsert != nil { return t.MockInsert(v, returnCol) }
     return
 }
 
-func (t *MockTable) Update(s string, i interface{})(e error) {
-    if t.MockUpdate != nil { return t.MockUpdate(s, i) }
+func (t *MockTable) Delete(w Filter)(e error) {
+    if t.MockDelete != nil { return t.MockDelete(w) }
     return
 }
 
-func (t *MockTable) SelectRow(s string, i interface{})(e error) {
-    if t.MockSelectRow != nil { return t.MockSelectRow(s, i) }
+func (t *MockTable) Update(to map[string]interface{}, w Filter)(e error) {
+    if t.MockUpdate != nil { return t.MockUpdate(to, w) }
     return
 }
 
-func (t *MockTable) InsertSchema(v map[string]interface{}, returnCol string)(i interface{}, e error) {
-    if t.MockInsertSchema != nil { return t.MockInsertSchema(v, returnCol) }
+func (t *MockTable) SelectRow(c []string, w Filter, d interface{})(e error) {
+    if t.MockSelectRow != nil { return t.MockSelectRow(c, w, d) }
     return
 }
 
-func (t *MockTable) DeleteRowsSchema(w Filter)(e error) {
-    if t.MockDeleteRowsSchema != nil { return t.MockDeleteRowsSchema(w) }
-    return
-}
-
-func (t *MockTable) UpdateSchema(to, w map[string]interface{})(e error) {
-    if t.MockUpdateSchema != nil { return t.MockUpdateSchema(to, w) }
-    return
-}
-
-func (t *MockTable) SelectRowSchema(c []string, w Filter, d interface{})(e error) {
-    if t.MockSelectRowSchema != nil { return t.MockSelectRowSchema(c, w, d) }
-    return
-}
-
-func (t *MockTable) SelectSchema(c []string, w Filter, opts SelectOptions)(s ScannerInterface, e error) {
-    if t.MockSelectSchema != nil { return t.MockSelectSchema(c, w, opts) }
+func (t *MockTable) Select(c []string, w Filter, opts SelectOptions)(s ScannerInterface, e error) {
+    if t.MockSelect != nil { return t.MockSelect(c, w, opts) }
     return
 }
 
@@ -102,7 +84,7 @@ func CommonTestingTable(schema Schema) *MockTable {
         i += 1
     }
 
-    table.MockInsertSchema = func(values map[string]interface{}, returnCol string)(interface{}, error) {
+    table.MockInsert = func(values map[string]interface{}, returnCol string)(interface{}, error) {
         addition := make([]interface{}, len(table.Schema))
 
         for k, orig := range values {
@@ -135,7 +117,7 @@ func CommonTestingTable(schema Schema) *MockTable {
         return nil, nil
     }
 
-    table.MockDeleteRowsSchema = func(where Filter)(error) {
+    table.MockDelete = func(where Filter)(error) {
         updated := false
         var toDelete []int
 
@@ -173,7 +155,7 @@ func CommonTestingTable(schema Schema) *MockTable {
         return nil
     }
 
-    table.MockUpdateSchema = func(to, where map[string]interface{})(error) {
+    table.MockUpdate = func(to map[string]interface{}, where Filter)(error) {
         updated := false
         for _, row := range table.Database {
 
@@ -200,7 +182,7 @@ func CommonTestingTable(schema Schema) *MockTable {
         return nil
     }
 
-    table.MockSelectRowSchema = func(cols []string, where Filter, dest interface{})(error) {
+    table.MockSelectRow = func(cols []string, where Filter, dest interface{})(error) {
 
         if cols == nil {
             cols = make([]string, len(table.Schema))
@@ -231,7 +213,7 @@ func CommonTestingTable(schema Schema) *MockTable {
         return NoRowsError
     }
 
-    table.MockSelectSchema = func(cols []string, where Filter, opts SelectOptions)(ScannerInterface, error) {
+    table.MockSelect = func(cols []string, where Filter, opts SelectOptions)(ScannerInterface, error) {
 
         if cols == nil {
             cols = make([]string, len(table.Schema))

--- a/databases/postgres/postgres.go
+++ b/databases/postgres/postgres.go
@@ -116,6 +116,29 @@ func setup() *postgresConn {
     return &postgresConn{postgres}
 }
 
+func (this *postgresCompiler) CompileCreate(table string) string {
+    var cols []string
+
+    for col, colType := range this.schema {
+        // JSON type doesn't have an equality operator which breaks queries
+        if strings.Contains(colType, "json") {
+            colType = "text"
+        }
+
+        cols = append(cols, fmt.Sprintf("%s %s", col, colType))
+    }
+
+    sort.Strings(cols)
+
+    colStr := strings.Join(cols, ", ")
+
+    return fmt.Sprintf(`CREATE TABLE %s (%s);`, table, colStr)
+}
+
+func (this *postgresCompiler) CompileDrop(table string) string {
+    return fmt.Sprintf(`DROP TABLE %s;`, table)
+}
+
 func (this *postgresCompiler) CompileInsert(table string, values map[string]interface{}) (string, []interface{}) {
     var valBuf bytes.Buffer
     queryVals := make([]interface{}, len(values))

--- a/databases/postgres/postgres.go
+++ b/databases/postgres/postgres.go
@@ -17,22 +17,27 @@ package postgres
 import (
     "os"
     "fmt"
+    "sort"
+    "bytes"
     "strings"
-
+    "encoding/json"
     "database/sql"
 
     "github.com/lib/pq"
 
     "github.com/lighthouse/lighthouse/logging"
-
     "github.com/lighthouse/lighthouse/databases"
 )
 
-type postgresConnection struct {
+type postgresConn struct {
     sql.DB
 }
 
-var connection *postgresConnection
+type postgresCompiler struct {
+    schema databases.Schema
+}
+
+var connection *postgresConn
 
 func Connection() databases.DBInterface {
     if connection == nil {
@@ -41,12 +46,15 @@ func Connection() databases.DBInterface {
     return connection
 }
 
-func (this *postgresConnection) Exec(cmd string, params ...interface{}) (sql.Result, error) {
-    res, err := this.DB.Exec(cmd, params...)
-    
+func (this *postgresConn) Exec(cmd string, params ...interface{}) (sql.Result, error) {
+    res, err := this.DB.Exec(cmd, params...)   
     err = transformError(err)
 
     return res, err
+}
+
+func (this *postgresConn) Compiler(schema databases.Schema) (databases.Compiler) {
+    return &postgresCompiler{schema}
 }
 
 func transformError(err error) error {
@@ -69,7 +77,7 @@ func transformError(err error) error {
     return nil
 }
 
-func setup() *postgresConnection {
+func setup() *postgresConn {
     postgresHost := os.Getenv("POSTGRES_PORT_5432_TCP_ADDR")
     dockerHost := os.Getenv("DOCKER_HOST")
 
@@ -104,5 +112,221 @@ func setup() *postgresConnection {
         panic(err.Error())
     }
 
-    return &postgresConnection{*postgres}
+    return &postgresConn{*postgres}
+}
+
+func (this *postgresCompiler) CompileInsert(table string, values map[string]interface{}) (string, []interface{}) {
+    var valBuf bytes.Buffer
+    queryVals := make([]interface{}, len(values))
+    i := 0
+    var keys []string
+
+    for col, _ := range values {
+        keys = append(keys, col)
+    }
+
+    sort.Strings(keys)
+
+    colBuf := strings.Join(keys, ", ")
+
+    for _, col := range keys {
+        val := values[col]
+        if i != 0 {
+            valBuf.WriteString(", ")
+        }
+
+        s := fmt.Sprintf(`($%d)`, i + 1)
+        valBuf.WriteString(s)
+
+        queryVals[i] = this.ConvertInput(val, col)
+
+        i += 1
+    }
+
+    query := fmt.Sprintf(`INSERT INTO %s (%s) VALUES (%s);`,
+        table, colBuf, valBuf.String())
+
+    return query, queryVals
+}
+
+func (this *postgresCompiler) CompileDelete(table string, where databases.Filter) (string, []interface{}) {
+    var buffer bytes.Buffer
+    vals := make([]interface{}, len(where))
+
+    buffer.WriteString("DELETE FROM ")
+    buffer.WriteString(table)
+
+    if len(where) > 0 {
+        buffer.WriteString(" WHERE ")
+
+        var whereKeys []string
+        for col, _ := range where {
+            whereKeys = append(whereKeys, col)
+        }
+        sort.Strings(whereKeys)
+
+        for i, col := range whereKeys {
+            val := where[col]
+            if i != 0 {
+                buffer.WriteString(" AND ")
+            }
+
+            buffer.WriteString(fmt.Sprintf("%s = ($%d)", col, i + 1))
+
+            vals[i] = this.ConvertInput(val, col)
+        }
+    }
+
+    buffer.WriteString(";")
+
+    return buffer.String(), vals
+}
+
+func (this *postgresCompiler) CompileUpdate(table string, to map[string]interface{}, where databases.Filter) (string, []interface{}) {
+    var buffer bytes.Buffer
+
+    buffer.WriteString("UPDATE ")
+    buffer.WriteString(table)
+    buffer.WriteString(" SET ")
+
+    vals := make([]interface{}, len(where) + len(to))
+    var toKeys, whereKeys []string
+    i := 1
+
+    for col, _ := range to {
+        toKeys = append(toKeys, col)
+    }
+
+    for col, _ := range where {
+        whereKeys = append(whereKeys, col)
+    }
+
+    sort.Strings(toKeys)
+    sort.Strings(whereKeys)
+
+    for _, col := range toKeys {
+        val := to[col]
+        if i != 1 {
+            buffer.WriteString(", ")
+        }
+
+        buffer.WriteString(fmt.Sprintf("%s = ($%d)", col, i))
+
+        vals[i - 1] = this.ConvertInput(val, col)
+        i += 1
+    }
+
+    buffer.WriteString(" WHERE ")
+
+    for _, col := range whereKeys {
+        val := where[col]
+        if i != len(to) + 1 {
+            buffer.WriteString(" AND ")
+        }
+
+        buffer.WriteString(fmt.Sprintf("%s = ($%d)", col, i))
+
+        vals[i - 1] = this.ConvertInput(val, col)
+        i += 1
+    }
+
+    buffer.WriteString(";")
+
+    return buffer.String(), vals
+}
+
+func (this *postgresCompiler) CompileSelect(table string, cols []string, where databases.Filter, opts *databases.SelectOptions) (string, []interface{}) {
+    if opts == nil {
+        opts = databases.DefaultSelectOptions()
+    }
+
+    var buffer bytes.Buffer
+
+    buffer.WriteString("SELECT ")
+
+    if opts.Distinct {
+        buffer.WriteString("DISTINCT ")
+    }
+
+    buffer.WriteString(strings.Join(cols, ", "))
+
+    buffer.WriteString(" FROM ") 
+    buffer.WriteString(table)
+
+    whereVals := make([]interface{}, len(where))
+    if where != nil {
+
+        buffer.WriteString(" WHERE ")
+
+        var whereKeys []string
+        for col, _ := range where {
+            whereKeys = append(whereKeys, col)
+        }
+
+        sort.Strings(whereKeys)
+
+        for i, col := range whereKeys {
+            val := where[col]
+            if i != 0 {
+                buffer.WriteString(" AND ")
+            }
+
+            buffer.WriteString(fmt.Sprintf("%s = ($%d)", col, i + 1))
+
+            whereVals[i] = val
+        }
+    }
+
+    if opts.OrderBy != nil {
+        buffer.WriteString(" ORDER BY ")
+        buffer.WriteString(strings.Join(opts.OrderBy, ", "))
+    }
+
+    if opts.Desc {
+        buffer.WriteString(" DESC")
+    }
+
+    if opts.Top > 0 {
+        buffer.WriteString(fmt.Sprintf(" LIMIT %d", opts.Top))
+    }
+
+    buffer.WriteString(";")
+
+    return buffer.String(), whereVals
+}
+
+func (this *postgresCompiler) ConvertInput(orig interface{}, col string) interface{} {
+    colType := this.schema[col]
+
+    if strings.Contains(colType, "json") {
+        b, _ := json.Marshal(orig)
+        return string(b)
+    }
+    
+    return orig
+}
+
+func (this *postgresCompiler) ConvertOutput(orig interface{}, col string) interface{} {
+    colType := this.schema[col]
+
+    if strings.Contains(colType, "text") {
+        return string(orig.([]byte))
+    }
+
+    if strings.Contains(colType, "json") {
+        var read interface{}
+
+        err := json.Unmarshal(orig.([]byte), &read)
+        if err != nil {
+            return orig
+        }
+
+        return read
+    }
+
+    if strings.Contains(colType, "int") {
+        return int(orig.(int64))
+    }
+    
+    return orig
 }

--- a/databases/postgres/postgres.go
+++ b/databases/postgres/postgres.go
@@ -66,9 +66,10 @@ func transformError(err error) error {
     } 
 
     if !ok {
-        return nil
+        return err
     }
 
+    // Code listed at https://github.com/lib/pq/blob/master/error.go
     switch pqErr.Code {
     case "23505": 
         return databases.DuplicateKeyError

--- a/databases/postgres/postgres.go
+++ b/databases/postgres/postgres.go
@@ -30,7 +30,7 @@ import (
 )
 
 type postgresConn struct {
-    sql.DB
+    *sql.DB
 }
 
 type postgresCompiler struct {
@@ -113,7 +113,7 @@ func setup() *postgresConn {
         panic(err.Error())
     }
 
-    return &postgresConn{*postgres}
+    return &postgresConn{postgres}
 }
 
 func (this *postgresCompiler) CompileInsert(table string, values map[string]interface{}) (string, []interface{}) {

--- a/databases/postgres/postgres_test.go
+++ b/databases/postgres/postgres_test.go
@@ -33,7 +33,7 @@ var testSchema databases.Schema = databases.Schema{
 
 func Test_Connection(t *testing.T) {
 	db, _ := sqlmock.New()
-	connection = &postgresConn{*db}
+	connection = &postgresConn{db}
 
 	res := Connection()
 
@@ -42,7 +42,7 @@ func Test_Connection(t *testing.T) {
 
 func Test_Compiler(t *testing.T) {
 	db, _ := sqlmock.New()
-	conn := &postgresConn{*db}
+	conn := &postgresConn{db}
 
 	var inter interface{}
 
@@ -70,7 +70,7 @@ func Test_TransformError(t *testing.T) {
 
 func Test_Exec(t *testing.T) {
 	db, _ := sqlmock.New()
-	conn := &postgresConn{*db}
+	conn := &postgresConn{db}
 
 	exec := `TEST EXEC`
 	args := []interface{}{42, "TEST", false}

--- a/databases/postgres/postgres_test.go
+++ b/databases/postgres/postgres_test.go
@@ -1,0 +1,115 @@
+// Copyright 2014 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+    "testing"
+
+    "strings"
+
+    "github.com/stretchr/testify/assert"
+
+    "github.com/lighthouse/lighthouse/databases"
+)
+
+var testSchema databases.Schema = databases.Schema{
+    "Name" : "text UNIQUE PRIMARY KEY",
+    "Age" : "integer",
+    "Phone" : "text",
+}
+
+func Test_CompileSelect_Default(t *testing.T) {
+    columns := []string {"Phone", "Name"}
+    where := databases.Filter {"Age" : 1, "Name" : "Sam"}
+
+    comp := &postgresCompiler{testSchema}
+    res, vars := comp.CompileSelect("TABLE", columns, where, nil)
+
+    keyQuery := "SELECT Phone, Name FROM TABLE WHERE "
+
+    assert.True(t, strings.HasPrefix(res, keyQuery))
+    res = res[len(keyQuery):]
+
+    assert.True(t, strings.Contains(res, "Age") && strings.Contains(res, "Name"))
+
+    if strings.HasPrefix(res, "Age") {
+        assert.Equal(t, 1, vars[0])
+        assert.Equal(t, "Sam", vars[1])
+    } else {
+        assert.Equal(t, "Sam", vars[0])
+        assert.Equal(t, 1, vars[1])
+    }
+}
+
+func Test_BuildQueryFrom_Options(t *testing.T) {
+    opts := databases.SelectOptions{
+        Distinct: true,
+        Top: 42,
+        OrderBy: []string{"C1", "C2"},
+        Desc: true,
+    }
+
+    comp := &postgresCompiler{testSchema}
+    res, vars := comp.CompileSelect("TABLE", []string{"Name"}, nil, &opts)
+
+    key := "SELECT DISTINCT Name FROM TABLE ORDER BY C1, C2 DESC LIMIT 42;"
+
+    assert.Equal(t, key, res)
+    assert.Equal(t, 0, len(vars))
+}
+
+func Test_ConvertInput(t *testing.T) {
+    type TestKeyPair struct{
+        Test interface{}
+        Key interface{}
+    }
+
+    tests := map[string]TestKeyPair {
+        "text" : TestKeyPair{"STRING_TEST", "STRING_TEST"},
+        "integer" : TestKeyPair{42, 42},
+        "json" : TestKeyPair{[]string{"TEST"}, `["TEST"]`},
+    }
+
+    shema := map[string]string{}
+    comp := &postgresCompiler{shema}
+
+    for trial, pair := range tests {
+        shema["COLUMN"] = trial
+        res := comp.ConvertInput(pair.Test, "COLUMN")
+        assert.Equal(t, pair.Key, res)
+    }
+}
+
+func Test_ConvertOutput(t *testing.T) {
+    type TestKeyPair struct{
+        Test interface{}
+        Key interface{}
+    }
+
+    tests := map[string]TestKeyPair {
+        "text" : TestKeyPair{[]byte("STRING_TEST"), "STRING_TEST"},
+        "integer" : TestKeyPair{int64(42), 42},
+        "json" : TestKeyPair{[]byte(`["TEST"]`), []interface{}{"TEST"}, },
+    }
+
+    shema := map[string]string{}
+    comp := &postgresCompiler{shema}
+
+    for trial, pair := range tests {
+        shema["COLUMN"] = trial
+        res := comp.ConvertOutput(pair.Test, "COLUMN")
+        assert.Equal(t, pair.Key, res)
+    }
+}

--- a/databases/postgres/postgres_test.go
+++ b/databases/postgres/postgres_test.go
@@ -17,9 +17,10 @@ package postgres
 import (
     "testing"
 
-    "strings"
+    "github.com/lib/pq"
 
     "github.com/stretchr/testify/assert"
+    "github.com/DATA-DOG/go-sqlmock"
 
     "github.com/lighthouse/lighthouse/databases"
 )
@@ -30,30 +31,131 @@ var testSchema databases.Schema = databases.Schema{
     "Phone" : "text",
 }
 
+func Test_Connection(t *testing.T) {
+	db, _ := sqlmock.New()
+	connection = &postgresConn{*db}
+
+	res := Connection()
+
+	assert.Equal(t, connection, res)
+}
+
+func Test_Compiler(t *testing.T) {
+	db, _ := sqlmock.New()
+	conn := &postgresConn{*db}
+
+	var inter interface{}
+
+	schema := databases.Schema{"this" : "junk"}
+	inter = conn.Compiler(schema)
+
+	comp, ok := inter.(*postgresCompiler)
+
+	assert.True(t, ok)
+	assert.Equal(t, schema, comp.schema)
+}
+
+func Test_TransformError(t *testing.T) {
+	tests := map[error]error {
+		nil : nil,
+		databases.EmptyKeyError : databases.EmptyKeyError,
+		&pq.Error{Code : "23505"} : databases.DuplicateKeyError,
+	}
+
+	for test, key := range tests {
+		res := transformError(test)
+		assert.Equal(t, key, res)
+	}
+}
+
+func Test_Exec(t *testing.T) {
+	db, _ := sqlmock.New()
+	conn := &postgresConn{*db}
+
+	exec := `TEST EXEC`
+	args := []interface{}{42, "TEST", false}
+
+	sqlmock.ExpectExec(exec).
+		WithArgs(42, "TEST", false).
+		WillReturnResult(sqlmock.NewResult(42, 73))
+
+	res, err := conn.Exec(exec, args...)
+
+	assert.Nil(t, err)
+
+	id, _ := res.LastInsertId()
+	assert.Equal(t, 42, id)
+
+	cnt, _ := res.RowsAffected()
+	assert.Equal(t, 73, cnt)
+}
+
+func Test_CompileInsert(t *testing.T) {
+    values := map[string]interface{}{"Age" : 1, "Name" : "Sam"}
+
+	comp := &postgresCompiler{testSchema}
+	exec, vars := comp.CompileInsert("TABLE", values)
+
+    key := "INSERT INTO TABLE (Age, Name) VALUES (($1), ($2));"
+    assert.Equal(t, key, exec)
+    assert.Equal(t, 1, vars[0])
+    assert.Equal(t, "Sam", vars[1])
+}
+
+func Test_CompileDelete(t *testing.T) {
+    where := map[string]interface{}{"Age" : 1, "Name" : "Sam"}
+
+	comp := &postgresCompiler{testSchema}
+	delete, vars := comp.CompileDelete("TABLE", where)
+
+    key := "DELETE FROM TABLE WHERE Age = ($1) AND Name = ($2);"
+    
+    assert.Equal(t, key, delete)
+    assert.Equal(t, 1, vars[0])
+    assert.Equal(t, "Sam", vars[1])
+}
+
+func Test_CompileDelete_All(t *testing.T) {
+	comp := &postgresCompiler{testSchema}
+	delete, vars := comp.CompileDelete("TABLE", nil)
+
+    key := "DELETE FROM TABLE;"
+    
+    assert.Equal(t, key, delete)
+    assert.Equal(t, 0, len(vars))
+}
+
+func Test_CompileUpdate(t *testing.T) {
+    to := map[string]interface{}{"Phone" : "123-456-7890", "Name" : "Pete"}
+    where := databases.Filter{"Age" : 1, "Name" : "Sam"}
+
+    comp := &postgresCompiler{testSchema}
+    update, vars := comp.CompileUpdate("TABLE", to, where)
+
+    key := "UPDATE TABLE SET Name = ($1), Phone = ($2) WHERE Age = ($3) AND Name = ($4);"
+
+    assert.Equal(t, key, update)
+    assert.Equal(t, "Pete", vars[0])
+    assert.Equal(t, "123-456-7890", vars[1])
+    assert.Equal(t, 1, vars[2])
+    assert.Equal(t, "Sam", vars[3])
+}
+
 func Test_CompileSelect_Default(t *testing.T) {
     columns := []string {"Phone", "Name"}
     where := databases.Filter {"Age" : 1, "Name" : "Sam"}
 
     comp := &postgresCompiler{testSchema}
-    res, vars := comp.CompileSelect("TABLE", columns, where, nil)
+    query, vars := comp.CompileSelect("TABLE", columns, where, nil)
 
-    keyQuery := "SELECT Phone, Name FROM TABLE WHERE "
+    key := "SELECT Phone, Name FROM TABLE WHERE Age = ($1) AND Name = ($2);"
 
-    assert.True(t, strings.HasPrefix(res, keyQuery))
-    res = res[len(keyQuery):]
-
-    assert.True(t, strings.Contains(res, "Age") && strings.Contains(res, "Name"))
-
-    if strings.HasPrefix(res, "Age") {
-        assert.Equal(t, 1, vars[0])
-        assert.Equal(t, "Sam", vars[1])
-    } else {
-        assert.Equal(t, "Sam", vars[0])
-        assert.Equal(t, 1, vars[1])
-    }
+    assert.Equal(t, key, query)
+    assert.Equal(t, 1, vars[0])
+    assert.Equal(t, "Sam", vars[1])
 }
 
-func Test_BuildQueryFrom_Options(t *testing.T) {
+func Test_CompileQuery_Options(t *testing.T) {
     opts := databases.SelectOptions{
         Distinct: true,
         Top: 42,

--- a/databases/postgres/postgres_test.go
+++ b/databases/postgres/postgres_test.go
@@ -90,6 +90,22 @@ func Test_Exec(t *testing.T) {
 	assert.Equal(t, 73, cnt)
 }
 
+func Test_CompileCreate(t *testing.T) {
+    comp := &postgresCompiler{testSchema}
+    exec := comp.CompileCreate("TABLE")
+
+    key := "CREATE TABLE TABLE (Age integer, Name text UNIQUE PRIMARY KEY, Phone text);"
+    assert.Equal(t, key, exec)
+}
+
+func TestCompileDrop(t *testing.T) {
+    comp := &postgresCompiler{testSchema}
+    exec := comp.CompileDrop("TABLE")
+
+    key := "DROP TABLE TABLE;"
+    assert.Equal(t, key, exec)
+}
+
 func Test_CompileInsert(t *testing.T) {
     values := map[string]interface{}{"Age" : 1, "Name" : "Sam"}
 

--- a/databases/scanner.go
+++ b/databases/scanner.go
@@ -37,7 +37,7 @@ func (this *Scanner) Scan(dest interface{}) error {
 
     rv := reflect.ValueOf(dest).Elem()
     for i, colName := range this.columns {
-        setVal := this.table.convertOutput(row[i], colName)
+        setVal := this.table.compiler.ConvertOutput(row[i], colName)
         if setVal != nil {
             rv.FieldByName(colName).Set(reflect.ValueOf(setVal))
         }

--- a/handlers/containers/applications/applications.go
+++ b/handlers/containers/applications/applications.go
@@ -32,7 +32,7 @@ type applicationData struct {
 
 func Init(reload bool) {
     if applications == nil {
-        applications = databases.NewSchemaTable(nil, "applications", schema)
+        applications = databases.NewTable(nil, "applications", schema)
     }
 
     if reload {
@@ -46,7 +46,7 @@ func CreateApplication(Name string) (int64, error) {
 //    values["Id"] = "DEFAULT"
     values["Name"] = Name
 
-    appId, err := applications.InsertSchema(values, "Id")
+    appId, err := applications.Insert(values, "Id")
     if err != nil {
         return -1, err
     }
@@ -63,7 +63,7 @@ func GetApplicationName(Id int64) (string, error) {
         columns = append(columns, k)
     }
 
-    err := applications.SelectRowSchema(columns, where, &application)
+    err := applications.SelectRow(columns, where, &application)
 
     if err != nil {
         return "", err
@@ -81,7 +81,7 @@ func GetApplicationId(Name string) (int64, error) {
         columns = append(columns, k)
     }
 
-    err := applications.SelectRowSchema(columns, where, &application)
+    err := applications.SelectRow(columns, where, &application)
 
     if err != nil {
         return -1, err

--- a/handlers/containers/containers.go
+++ b/handlers/containers/containers.go
@@ -36,7 +36,7 @@ type Container struct {
 
 func Init(reload bool) {
     if containers == nil {
-        containers = databases.NewSchemaTable(nil, "containers", schema)
+        containers = databases.NewTable(nil, "containers", schema)
     }
 
     if reload {
@@ -51,7 +51,7 @@ func CreateContainer(AppId int64, DockerInstance string, Name string) (int64, er
     values["DockerInstance"] = DockerInstance
     values["Name"] = Name
 
-    containerId, err := containers.InsertSchema(values, "Id")
+    containerId, err := containers.Insert(values, "Id")
     if err != nil {
         return -1, err
     }
@@ -61,7 +61,7 @@ func CreateContainer(AppId int64, DockerInstance string, Name string) (int64, er
 
 func DeleteContainer(Id int64) (err error) {
     where := databases.Filter{"Id" : Id}
-    return containers.DeleteRowsSchema(where)
+    return containers.Delete(where)
 }
 
 func GetContainerById(Id int64, container *Container) (err error) {
@@ -72,7 +72,7 @@ func GetContainerById(Id int64, container *Container) (err error) {
         columns = append(columns, k)
     }
 
-    err = containers.SelectRowSchema(columns, where, container)
+    err = containers.SelectRow(columns, where, container)
 
     return
 }


### PR DESCRIPTION
## What

A major overhaul of the databases package to lay groundwork for additional drivers.
- Removed all non-schema methods - all tables **must** be schema-ed
- Solved the `INSERT ... RETURNING` compatibility issue
- Solved the issue of different database types using different syntaxes
## How

>  Solved the `INSERT ... RETURNING` compatibility issue
- Created a `LockingTable` (really just an option field in the existing `Table` type.
  - The table has a `sync.Mutex` which is used to lock the table
  - Currently only `INSERT`s lock the table
- Broke the `Insert(values, returning)` method into `Insert( ... )` and `InsertReturn( ... )`
  - `Insert( ... )` locks the table, runs an `INSERT`, and unlocks
  - `InsertReturn( ... )` locks the table, runs an `INSERT` followed by a `SELECT`), and unlocks
  - All tables can call `Insert()`, only LockingTables can call `InsertReturn()`

>  Solved the issue of different database types using different syntaxes
- Added the `databases.Compiler` type
  - Knows the syntax of one database type and, given parameters, creates Execs and Queries for that type
  - Each database will probably need its own version (there may be small overlap*)
- Added a `Compiler()` method to `DBInterface` which gets a compiler for that database

``` go
db := postgres.Connection()
comp := db.Compiler(mySchema)
query, args := comp.CompileSelect( ... )
```
## Why

Supporting new databases other than postgres.  The syntax differences alone were enough to make adding new types impossible in our current structure. 
## Testing

Tests for the database package appear weaker, but are actually just as strong.  This is because the database relies on a compiler to function properly, but like usual we can't rely on one specific type of compiler.  As mock compiler is used in the tests which creates queries that are simply the command (`INSERT`, `DELETE`, etc).  Because `sqlmock` is handling all our return values, these simple commands don't affect any actual behaviors.

Tests are added for the postgres package to ensure that it creates the right queries for the various commands.

_*_ the postgres compiler is now our largest source file sooooo... yeah.
