### PR TITLE
Read session key from file

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -15,13 +15,39 @@
 package session
 
 import (
+    "os"
+    "io/ioutil"
     "net/http"
 
     "github.com/gorilla/sessions"
     "github.com/gorilla/securecookie"
 )
 
-var cookieStore = sessions.NewCookieStore(securecookie.GenerateRandomKey(32))
+var cookieStore *sessions.CookieStore
+
+func init() {
+    sessionKey, err := loadSessionKey(os.TempDir() + "lighthouse_session.key")
+
+    if err != nil {
+        panic(err.Error())
+    }
+
+    cookieStore = sessions.NewCookieStore(sessionKey)
+}
+
+func loadSessionKey(sessionFile string) ([]byte, error) {
+    var sessionKey []byte
+    _, err := os.Stat(sessionFile)
+
+    if os.IsNotExist(err) {
+        sessionKey = securecookie.GenerateRandomKey(64)
+        err = ioutil.WriteFile(sessionFile, sessionKey, 0640)
+    } else {
+        sessionKey, err = ioutil.ReadFile(sessionFile)
+    }
+
+    return sessionKey, err
+}
 
 func GetValueOK(r *http.Request, sessionKey string, key interface{}) (interface{}, bool) {
     session := GetSession(r, sessionKey)

--- a/session/session.go
+++ b/session/session.go
@@ -16,6 +16,7 @@ package session
 
 import (
     "os"
+    "path"
     "io/ioutil"
     "net/http"
 
@@ -26,7 +27,8 @@ import (
 var cookieStore *sessions.CookieStore
 
 func init() {
-    sessionKey, err := loadSessionKey(os.TempDir() + "lighthouse_session.key")
+    sessionKey, err := loadSessionKey(
+        path.Join(os.TempDir(), "lighthouse_session.key"))
 
     if err != nil {
         panic(err.Error())

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -15,6 +15,8 @@
 package session
 
 import (
+    "os"
+    "io/ioutil"
     "testing"
     "net/http"
 
@@ -89,4 +91,25 @@ func Test_SetValue_Overwrite(t *testing.T) {
     value := s.Values["key"]
 
     assert.Equal(t, "right_value", value)
+}
+
+func Test_LoadSessionKey_Cold(t *testing.T) {
+    os.Remove("test_session_cold.key")
+
+    sessionKey, _ := loadSessionKey("test_session_cold.key")
+    assert.Len(t, sessionKey, 64)
+
+    os.Remove("test_session_cold.key")
+}
+
+func Test_LoadSessionKey_Warm(t *testing.T) {
+    os.Remove("test_session_warm.key")
+
+    expectedKey := []byte{'d', 'e', 'a', 'd', 'b', 'e', 'e', 'f'}
+    ioutil.WriteFile("test_session_warm.key", expectedKey, 0644)
+
+    actualKey, _ := loadSessionKey("test_session_warm.key")
+    assert.Equal(t, expectedKey, actualKey)
+
+    os.Remove("test_session_warm.key")
 }


### PR DESCRIPTION
Read the session key from a tmp file to help persist user sessions.  Currently if lighthouse restarts the user is forced to re-auth. This fixes that.
