### PR TITLE
Test beacon validity on create

### DIFF
--- a/beacons/aliases/aliases.go
+++ b/beacons/aliases/aliases.go
@@ -57,6 +57,11 @@ func AddAlias(alias, address string) error {
     return err
 }
 
+func RemoveAlias(address string) error {
+    where := databases.Filter{"Address" : address}
+    return aliases.DeleteRowsSchema(where)
+}
+
 func UpdateAlias(alias, address string) error {
     to := databases.Filter{"Alias": alias}
     where := databases.Filter{"Address" : address}

--- a/beacons/aliases/aliases_test.go
+++ b/beacons/aliases/aliases_test.go
@@ -109,6 +109,24 @@ func Test_SetAlias(t *testing.T) {
 	assert.Equal(t, addedAlias, real.Alias)
 }
 
+func Test_RemoveAlias(t *testing.T) {
+	table, teardown := setup()
+	defer teardown()
+
+	table.InsertSchema(map[string]interface{}{
+		"Alias" : "ALIAS",
+		"Address" : "ADDRESS",
+	}, "")
+
+	RemoveAlias("ADDRESS")
+
+	var res Alias
+	err := table.SelectRowSchema([]string{"Address"}, nil, &res)
+
+	assert.Equal(t, databases.NoRowsError, err)
+}
+
+
 func Test_GetAddressOf(t *testing.T) {
 	table, teardown := setup()
 	defer teardown()

--- a/beacons/handlers.go
+++ b/beacons/handlers.go
@@ -129,14 +129,6 @@ func handleBeaconCreate(w http.ResponseWriter, r *http.Request) {
     currentUser := auth.GetCurrentUser(r)
     auth.SetUserBeaconAuthLevel(currentUser, beacon.Address, auth.OwnerAuthLevel)
 
-    // _, err = net.DialTimeout("ip", "http://" + beacon.Address, 
-    //     time.Duration(3) * time.Second)
-    // if err != nil {
-    //     return
-    // }
-
-    // TODO - rollback on error
-
     err = aliases.AddAlias(beaconInfo.Alias, beaconInfo.Address)
     if err != nil {
         return
@@ -148,10 +140,17 @@ func handleBeaconCreate(w http.ResponseWriter, r *http.Request) {
     }
 
     if err != nil {
+        aliases.RemoveAlias(beaconInfo.Address)
         return
     }
 
     err = refreshVMListOf(beacon)
+    if err != nil {
+        aliases.RemoveAlias(beaconInfo.Address)
+        removeBeacon(beacon.Address)
+        return
+    }
+
     return
 }
 

--- a/beacons/handlers_test.go
+++ b/beacons/handlers_test.go
@@ -29,6 +29,7 @@ import (
 
     "github.com/lighthouse/lighthouse/auth"
     "github.com/lighthouse/lighthouse/session"
+    "github.com/lighthouse/lighthouse/databases"
     "github.com/lighthouse/lighthouse/beacons/aliases"
 )
 
@@ -173,6 +174,9 @@ func Test_HandleBeaconCreate_Invalid(t *testing.T) {
 	body = map[string]interface{} {"Address" : "ADDR", "Alias" : "ALIAS", "Token" : ""}
 	w = runHandlerTest("POST", "/", body, "/", handleBeaconCreate)
 	assert.Equal(t, 500, w.Code)
+	var beacon beaconData
+	err := beacons.SelectRowSchema(nil, nil, &beacon)
+	assert.Equal(t, databases.NoRowsError, err)
 
 	// Duplicate beacon
 	body = map[string]interface{} {"Address" : "localhost:8080", "Token" : ""}

--- a/beacons/helpers.go
+++ b/beacons/helpers.go
@@ -53,6 +53,11 @@ func addBeacon(beacon beaconData) error {
     return err
 }
 
+func removeBeacon(address string) error {
+    where := databases.Filter{"Address" : address}
+    return beacons.DeleteRowsSchema(where)
+}
+
 func addInstance(instance instanceData) error {
     entry := map[string]interface{}{
         "InstanceAddress" : instance.InstanceAddress,

--- a/beacons/helpers.go
+++ b/beacons/helpers.go
@@ -13,6 +13,7 @@ package beacons
 
 import (
     "fmt"
+    "time"
     "errors"
     "encoding/json"
     "io/ioutil"
@@ -195,7 +196,11 @@ func refreshVMListOf(beacon beaconData) error {
     // Assuming user has permission to access token since they provided it
     req.Header.Set(HEADER_TOKEN_KEY, beacon.Token)
 
-    resp, err := http.DefaultClient.Do(req)
+    client := http.Client{
+        Timeout: time.Duration(3 * time.Second),
+    }
+
+    resp, err := client.Do(req)
     if err != nil {
         return err
     }

--- a/beacons/helpers_test.go
+++ b/beacons/helpers_test.go
@@ -26,6 +26,7 @@ import (
 
     "github.com/lighthouse/beacon/structs"
 
+    "github.com/lighthouse/lighthouse/databases"
     "github.com/lighthouse/lighthouse/auth"
     "github.com/lighthouse/lighthouse/beacons/aliases"
 )
@@ -102,6 +103,24 @@ func Test_AddBeaconData_Dup(t *testing.T) {
 
     assert.NotNil(t, addBeacon(testBeaconData))
 }
+
+func Test_RemoveBeacon(t *testing.T) {
+    setup()
+    defer teardown()
+
+    beacons.InsertSchema(map[string]interface{}{
+        "Address" : "ADDR",
+        "Token" : "TOKEN",
+    }, "")
+
+    removeBeacon("ADDR")
+
+    var values beaconData
+    err := beacons.SelectRowSchema(nil, nil, &values)
+
+    assert.Equal(t, databases.NoRowsError, err)
+}
+
 
 func Test_AddInstanceData_New(t *testing.T) {
     setup()

--- a/databases/databases.go
+++ b/databases/databases.go
@@ -400,18 +400,14 @@ func buildQueryFrom(table string, columns []string, where Filter, opts SelectOpt
         buffer.WriteString("DISTINCT ")
     }
 
-    if columns == nil {
-        buffer.WriteString("*")
-    } else {
-        first := true
-        for _, col := range columns {
-            if !first {
-                buffer.WriteString(", ")
-            }
-            buffer.WriteString(col)
-
-            first = false
+    first := true
+    for _, col := range columns {
+        if !first {
+            buffer.WriteString(", ")
         }
+        buffer.WriteString(col)
+
+        first = false
     }
 
     buffer.WriteString(" FROM ") 
@@ -450,8 +446,6 @@ func buildQueryFrom(table string, columns []string, where Filter, opts SelectOpt
 }
 
 func (this *Table) SelectRowSchema(columns []string, where Filter, dest interface{}) error {
-    query, queryVals := buildQueryFrom(this.table, columns, where, SelectOptions{})
-
     if columns == nil || len(columns) == 0 {
         columns = make([]string, len(this.schema))
 
@@ -462,6 +456,8 @@ func (this *Table) SelectRowSchema(columns []string, where Filter, dest interfac
         }
         sort.Strings(columns)
     }
+
+    query, queryVals := buildQueryFrom(this.table, columns, where, SelectOptions{})
 
     row := this.db.QueryRow(query, queryVals...)
 
@@ -498,8 +494,6 @@ func (this *Table) SelectRowSchema(columns []string, where Filter, dest interfac
 }
 
 func (this *Table) SelectSchema(columns []string, where Filter, opts SelectOptions) (ScannerInterface, error) {
-    query, queryVals := buildQueryFrom(this.table, columns, where, opts)
-
     if columns == nil || len(columns) == 0 {
         columns = make([]string, len(this.schema))
 
@@ -509,6 +503,8 @@ func (this *Table) SelectSchema(columns []string, where Filter, opts SelectOptio
             i += 1
         }
     }
+
+    query, queryVals := buildQueryFrom(this.table, columns, where, opts)
 
     rows, err := this.db.Query(query, queryVals...)
 


### PR DESCRIPTION
If there is an error getting the VMs from a beacon in `/beacons/create` then the beacon (and alias) are not added.  An error is returned, just like it was originally.
