### PR TITLE
Removed schema methods from beacons and aliases

### DIFF
--- a/beacons/aliases/aliases.go
+++ b/beacons/aliases/aliases.go
@@ -63,7 +63,7 @@ func AddAlias(alias, address string) error {
 
 func RemoveAlias(address string) error {
     where := databases.Filter{"Address" : address}
-    return aliases.DeleteRowsSchema(where)
+    return aliases.Delete(where)
 }
 
 func UpdateAlias(alias, address string) error {

--- a/beacons/aliases/aliases_test.go
+++ b/beacons/aliases/aliases_test.go
@@ -113,15 +113,15 @@ func Test_RemoveAlias(t *testing.T) {
 	table, teardown := setup()
 	defer teardown()
 
-	table.InsertSchema(map[string]interface{}{
+	table.Insert(map[string]interface{}{
 		"Alias" : "ALIAS",
 		"Address" : "ADDRESS",
-	}, "")
+	})
 
 	RemoveAlias("ADDRESS")
 
 	var res Alias
-	err := table.SelectRowSchema([]string{"Address"}, nil, &res)
+	err := table.SelectRow([]string{"Address"}, nil, nil, &res)
 
 	assert.Equal(t, databases.NoRowsError, err)
 }

--- a/beacons/handlers_test.go
+++ b/beacons/handlers_test.go
@@ -175,7 +175,7 @@ func Test_HandleBeaconCreate_Invalid(t *testing.T) {
 	w = runHandlerTest("POST", "/", body, "/", handleBeaconCreate)
 	assert.Equal(t, 500, w.Code)
 	var beacon beaconData
-	err := beacons.SelectRowSchema(nil, nil, &beacon)
+	err := beacons.SelectRow(nil, nil, nil, &beacon)
 	assert.Equal(t, databases.NoRowsError, err)
 
 	// Duplicate beacon

--- a/beacons/helpers.go
+++ b/beacons/helpers.go
@@ -56,7 +56,7 @@ func addBeacon(beacon beaconData) error {
 
 func removeBeacon(address string) error {
     where := databases.Filter{"Address" : address}
-    return beacons.DeleteRowsSchema(where)
+    return beacons.Delete(where)
 }
 
 func addInstance(instance instanceData) error {

--- a/beacons/helpers_test.go
+++ b/beacons/helpers_test.go
@@ -108,15 +108,15 @@ func Test_RemoveBeacon(t *testing.T) {
     setup()
     defer teardown()
 
-    beacons.InsertSchema(map[string]interface{}{
+    beacons.Insert(map[string]interface{}{
         "Address" : "ADDR",
         "Token" : "TOKEN",
-    }, "")
+    })
 
     removeBeacon("ADDR")
 
     var values beaconData
-    err := beacons.SelectRowSchema(nil, nil, &values)
+    err := beacons.SelectRow(nil, nil, nil, &values)
 
     assert.Equal(t, databases.NoRowsError, err)
 }


### PR DESCRIPTION
Somehow the databases update didn't cause conflicts in the beacon validation branch.  Fixing that.
